### PR TITLE
Fix various issues with the Loki Push API library

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -976,8 +976,7 @@ class LokiPushApiConsumer(RelationManagerBase):
         self._charm = charm
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
-        limit = self._charm.meta.relations[self._relation_name].limit
-        self._is_multi = True if type(limit) == int and limit > 0 else False
+        self._is_multi = self._charm.meta.relations[self._relation_name].limit != 1
 
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_logging_relation_changed)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1006,7 +1006,7 @@ class LokiPushApiConsumer(RelationManagerBase):
                 self._process_logging_relation_changed(relation)
 
     def _process_logging_relation_changed(self, relation: Relation):
-        loki_push_api = relation.data[relation.app].get("loki_push_api")
+        loki_push_api_data = relation.data[relation.app].get("loki_push_api")
 
         if loki_push_api_data:
             self._stored.loki_push_api[relation.id] = json.loads(loki_push_api_data)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -289,7 +289,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1063,23 +1063,13 @@ class LokiPushApiConsumer(RelationManagerBase):
         return rule
 
     @property
-    def loki_push_api(self):
-        """Fetch Loki Push API endpoint sent from LokiPushApiProvider through relation data.
+    def loki_push_api(self) -> List[str]:
+        """Fetch Loki Push API endpoints sent from LokiPushApiProvider through relation data.
 
         Returns:
-            The Loki Push API endpoint (or None) if the relation this `LokiPushApiConsumer` tracks
-            has limit 1; with any other relation limit, it returns a list of Loki Push API
-            endpoints, which may be empty in case there are no relation instances.
+            A list with Loki Push API endpoints.
         """
-        loki_endpoints = [  # Convert from the StoredSet data structure to a plain list``
+        return [
             _type_convert_stored(loki_endpoint)
             for loki_endpoint in self._stored.loki_push_api.values()
         ]
-
-        if self._is_multi:
-            return loki_endpoints
-        else:
-            if len(loki_endpoints) == 1:
-                return loki_endpoints[0]
-            else:
-                return None

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1034,7 +1034,7 @@ class LokiPushApiConsumer(RelationManagerBase):
         the consumer charm is informed, through a `LokiPushApiEndpointDeparted` event.
         The consumer charm can then choose to update its configuration.
         """
-        self._stored.loki_push_api[event.relation.id] = None
+        self._stored.loki_push_api.pop(event.relation.id)
         self.on.loki_push_api_endpoint_departed.emit()
 
     def _set_alert_rules(self, relation: Relation):

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -955,7 +955,8 @@ class LokiPushApiConsumer(RelationManagerBase):
         self._charm = charm
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
-        self._is_multi = self._charm.meta.relations[self._relation_name].limit != 1
+        limit = self._charm.meta.relations[self._relation_name].limit
+        self._is_multi = True if type(limit) == int and limit > 0 else False
 
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_logging_relation_changed)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -789,7 +789,7 @@ class LokiPushApiProvider(RelationManagerBase):
             logger.debug("Saved Loki url in relation data %s", self._loki_push_api)
 
         if relation.data.get(relation.app).get("alert_rules"):
-            logger.debug("Saving alerts rules to disk")
+            logger.debug("Saved alerts rules to disk")
             self._remove_alert_rules_files(self.container)
             self._generate_alert_rules_files(self.container)
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -936,6 +936,8 @@ class LokiPushApiConsumer(RelationManagerBase):
         self._charm = charm
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
+        self._is_multi = self._charm.meta.relations[self._relation_name].limit != 1
+
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_logging_relation_changed)
         self.framework.observe(events.relation_changed, self._on_logging_relation_changed)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -976,7 +976,6 @@ class LokiPushApiConsumer(RelationManagerBase):
         self._charm = charm
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
-        self._is_multi = self._charm.meta.relations[self._relation_name].limit != 1
 
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_logging_relation_changed)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -77,7 +77,7 @@ For example a Loki charm may instantiate the
                 self.unit.status = BlockedStatus(str(e))
 
 
-The `LokiPushApiProvider` object has several main responsibilities:
+The `LokiPushApiProvider` object has several responsibilities:
 
 1. Set the URL of the Loki Push API in the provider app data bag; the URL
    must be unique to all instances (e.g., using a load balancer).
@@ -786,7 +786,7 @@ class LokiPushApiProvider(RelationManagerBase):
         """
         if self._charm.unit.is_leader():
             relation.data[self._charm.app].update({"loki_push_api": self._loki_push_api})
-            logger.debug("Saving Loki url in relation data %s", self._loki_push_api)
+            logger.debug("Saved Loki url in relation data %s", self._loki_push_api)
 
         if relation.data.get(relation.app).get("alert_rules"):
             logger.debug("Saving alerts rules to disk")

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1006,7 +1006,9 @@ class LokiPushApiConsumer(RelationManagerBase):
                 self._process_logging_relation_changed(relation)
 
     def _process_logging_relation_changed(self, relation: Relation):
-        if loki_push_api_data := relation.data[relation.app].get("loki_push_api"):
+        loki_push_api = relation.data[relation.app].get("loki_push_api")
+
+        if loki_push_api_data:
             self._stored.loki_push_api[relation.id] = json.loads(loki_push_api_data)
 
         if self._charm.unit.is_leader():

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1062,7 +1062,8 @@ class LokiPushApiConsumer(RelationManagerBase):
             endpoints, which may be empty in case there are no relation instances.
         """
         loki_endpoints = [  # Convert from the StoredSet data structure to a plain list``
-            _type_convert_stored(loki_endpoint) for loki_endpoint in self._stored.loki_push_api.values()
+            _type_convert_stored(loki_endpoint)
+            for loki_endpoint in self._stored.loki_push_api.values()
         ]
 
         if self._is_multi:

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -795,7 +795,9 @@ class LokiPushApiProvider(RelationManagerBase):
     @property
     def unit_ip(self) -> str:
         """Returns unit's IP."""
-        if bind_address := self._charm.model.get_binding(self._relation_name).network.bind_address:
+        bind_address = self._charm.model.get_binding(self._relation_name).network.bind_address
+
+        if bind_address:
             return str(bind_address)
         return ""
 

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -117,7 +117,7 @@ class TestLokiPushApiConsumer(unittest.TestCase):
             self.harness.charm.loki_consumer._stored.loki_push_api.get(rel_id)["url"],
             loki_push_api,
         )
-        self.assertEqual(self.harness.charm.loki_consumer.loki_push_api, {"url": loki_push_api})
+        self.assertEqual(self.harness.charm.loki_consumer.loki_push_api, [{"url": loki_push_api}])
 
     @patch("charms.loki_k8s.v0.loki_push_api.LoggingEvents.loki_push_api_endpoint_joined")
     def test__on_upgrade_charm_endpoint_joined_event_fired_for_leader(self, mock_events):

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -117,7 +117,7 @@ class TestLokiPushApiConsumer(unittest.TestCase):
             self.harness.charm.loki_consumer._stored.loki_push_api.get(rel_id)["url"],
             loki_push_api,
         )
-        self.assertEqual(self.harness.charm.loki_consumer.loki_push_api[0], {"url": loki_push_api})
+        self.assertEqual(self.harness.charm.loki_consumer.loki_push_api, {"url": loki_push_api})
 
     @patch("charms.loki_k8s.v0.loki_push_api.LoggingEvents.loki_push_api_endpoint_joined")
     def test__on_upgrade_charm_endpoint_joined_event_fired_for_leader(self, mock_events):

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -110,12 +110,14 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             "promtail",
-            {"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
+            {"loki_push_api": '{"url": "http://10.1.2.3:3100/loki/api/v1/push"}'},
         )
 
         self.assertEqual(
-            self.harness.charm.loki_consumer._stored.loki_push_api.get(rel_id), loki_push_api
+            self.harness.charm.loki_consumer._stored.loki_push_api.get(rel_id)["url"],
+            loki_push_api,
         )
+        self.assertEqual(self.harness.charm.loki_consumer.loki_push_api[0], {"url": loki_push_api})
 
     @patch("charms.loki_k8s.v0.loki_push_api.LoggingEvents.loki_push_api_endpoint_joined")
     def test__on_upgrade_charm_endpoint_joined_event_fired_for_leader(self, mock_events):

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -117,6 +117,32 @@ class TestLokiPushApiConsumer(unittest.TestCase):
             self.harness.charm.loki_consumer._stored.loki_push_api.get(rel_id), loki_push_api
         )
 
+    @patch("charms.loki_k8s.v0.loki_push_api.LoggingEvents.loki_push_api_endpoint_joined")
+    def test__on_upgrade_charm_endpoint_joined_event_fired_for_leader(self, mock_events):
+        self.harness.set_leader(True)
+
+        rel_id = self.harness.add_relation("logging", "promtail")
+        self.harness.add_relation_unit(rel_id, "promtail/0")
+        self.harness.update_relation_data(
+            rel_id,
+            "promtail",
+            {"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
+        )
+        mock_events.emit.assert_called_once()
+
+    @patch("charms.loki_k8s.v0.loki_push_api.LoggingEvents.loki_push_api_endpoint_joined")
+    def test__on_upgrade_charm_endpoint_joined_event_fired_for_follower(self, mock_events):
+        self.harness.set_leader(False)
+
+        rel_id = self.harness.add_relation("logging", "promtail")
+        self.harness.add_relation_unit(rel_id, "promtail/0")
+        self.harness.update_relation_data(
+            rel_id,
+            "promtail",
+            {"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
+        )
+        mock_events.emit.assert_called_once()
+
     def test__label_alert_topology(self):
         labeled_alert_topology = self.harness.charm.loki_consumer._label_alert_topology(
             ONE_RULE.copy()

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -82,7 +82,7 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         self.harness.set_leader(False)
         rel_id = self.harness.add_relation("logging", "promtail")
         self.harness.add_relation_unit(rel_id, "promtail/0")
-        self.assertEqual(self.harness.update_relation_data(rel_id, "promtail/0", {}), None)
+        self.assertEqual(self.harness.update_relation_data(rel_id, "promtail", {}), None)
 
     def test__on_logging_relation_changed_no_unit(self):
         self.harness.set_leader(True)
@@ -109,10 +109,13 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "promtail/0")
         self.harness.update_relation_data(
             rel_id,
-            "promtail/0",
+            "promtail",
             {"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
         )
-        self.assertEqual(self.harness.charm.loki_consumer._stored.loki_push_api, loki_push_api)
+
+        self.assertEqual(
+            self.harness.charm.loki_consumer._stored.loki_push_api.get(rel_id), loki_push_api
+        )
 
     def test__label_alert_topology(self):
         labeled_alert_topology = self.harness.charm.loki_consumer._label_alert_topology(

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -123,7 +123,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
             self.harness.update_relation_data(rel_id, "promtail", {"alert_rules": "ww"})
             self.assertEqual(
                 sorted(logger.output)[1],
-                "DEBUG:charms.loki_k8s.v0.loki_push_api:Saving alerts rules to disk",
+                "DEBUG:charms.loki_k8s.v0.loki_push_api:Saved alerts rules to disk",
             )
 
     @patch("ops.testing._TestingPebbleClient.make_dir")

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -105,7 +105,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
     )
     def test_relation_data(self, mock_unit_ip, *unused):
         mock_unit_ip.return_value = "10.1.2.3"
-        expected_value = '{"loki_push_api": {"url": "http://10.1.2.3:3100/loki/api/v1/push"}}'
+        expected_value = '{"url": "http://10.1.2.3:3100/loki/api/v1/push"}'
         self.assertEqual(expected_value, self.harness.charm.loki_provider._loki_push_api)
 
     @patch("ops.testing._TestingPebbleClient.make_dir")

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -105,7 +105,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
     )
     def test_relation_data(self, mock_unit_ip, *unused):
         mock_unit_ip.return_value = "10.1.2.3"
-        expected_value = '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'
+        expected_value = '{"loki_push_api": {"url": "http://10.1.2.3:3100/loki/api/v1/push"}}'
         self.assertEqual(expected_value, self.harness.charm.loki_provider._loki_push_api)
 
     @patch("ops.testing._TestingPebbleClient.make_dir")
@@ -119,11 +119,6 @@ class TestLokiPushApiProvider(unittest.TestCase):
             mock_unit_ip.return_value = "10.1.2.3"
             rel_id = self.harness.add_relation("logging", "promtail")
             self.harness.add_relation_unit(rel_id, "promtail/0")
-            self.harness.update_relation_data(rel_id, "promtail/0", {})
-            self.assertEqual(
-                sorted(logger.output)[0],
-                'DEBUG:charms.loki_k8s.v0.loki_push_api:Saving Loki url in relation data {"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}',
-            )
 
             self.harness.update_relation_data(rel_id, "promtail", {"alert_rules": "ww"})
             self.assertEqual(


### PR DESCRIPTION
1) Send the endpoint URL over application databags rather than unit (which will not work with distributed Loki)
2) Correctly handle multiple instances of the relation, avoiding concurrent overriding of the endpoint data in the Consumer storage
3) Support the upgrade of charms that include the LokiPushApiConsumer
4) Make the relation databag for the Loki endpoint extensible (using a dict rather than just a string to communicate the URL)