### PR TITLE
Use events for LogProxy, get rid of PromtailError as Exception

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -7,8 +7,22 @@ import json
 import logging
 from typing import Dict, List, Optional
 
-from ops.charm import CharmBase, CharmEvents, RelationDepartedEvent, RelationJoinedEvent
-from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationDepartedEvent,
+    RelationJoinedEvent,
+    RelationRole,
+)
+from ops.framework import (
+    EventBase,
+    EventSource,
+    Object,
+    ObjectEvents,
+    StoredDict,
+    StoredList,
+    StoredState,
+)
 from ops.model import Relation
 
 # The unique Charmhub library identifier, never change it
@@ -19,9 +33,122 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "grafana-source"
+RELATION_INTERFACE_NAME = "grafana_datasource"
+
+
+def _type_convert_stored(obj):
+    """Convert Stored* to their appropriate types, recursively."""
+    if isinstance(obj, StoredList):
+        return list(map(_type_convert_stored, obj))
+    elif isinstance(obj, StoredDict):
+        rdict = {}
+        for k in obj.keys():
+            rdict[k] = _type_convert_stored(obj[k])
+        return rdict
+    else:
+        return obj
+
+
+class RelationNotFoundError(Exception):
+    """Raised if there is no relation with the given name."""
+
+    def __init__(self, relation_name: str):
+        self._relation_name = relation_name
+        self.message = "No relation named '{}' found".format(relation_name)
+
+        super().__init__(self.message)
+
+
+class RelationInterfaceMismatchError(Exception):
+    """Raised if the relation with the given name has a different interface."""
+
+    def __init__(
+        self,
+        relation_name: str,
+        expected_relation_interface: str,
+        actual_relation_interface: str,
+    ):
+        self._relation_name = relation_name
+        self.expected_relation_interface = expected_relation_interface
+        self.actual_relation_interface = actual_relation_interface
+        self.message = (
+            "The '{}' relation has '{}' as "
+            "interface rather than the expected '{}'".format(
+                relation_name, actual_relation_interface, expected_relation_interface
+            )
+        )
+
+        super().__init__(self.message)
+
+
+class RelationRoleMismatchError(Exception):
+    """Raised if the relation with the given name has a different direction."""
+
+    def __init__(
+        self,
+        relation_name: str,
+        expected_relation_role: RelationRole,
+        actual_relation_role: RelationRole,
+    ):
+        self._relation_name = relation_name
+        self.expected_relation_interface = expected_relation_role
+        self.actual_relation_role = actual_relation_role
+        self.message = "The '{}' relation has role '{}' rather than the expected '{}'".format(
+            relation_name, repr(actual_relation_role), repr(expected_relation_role)
+        )
+
+        super().__init__(self.message)
+
+
+def _validate_relation_by_interface_and_direction(
+    charm: CharmBase,
+    relation_name: str,
+    expected_relation_interface: str,
+    expected_relation_role: RelationRole,
+) -> None:
+    """Verifies that a relation has the necessary characteristics.
+
+    Verifies that the `relation_name` provided: (1) exists in metadata.yaml,
+    (2) declares as interface the interface name passed as `relation_interface`
+    and (3) has the right "direction", i.e., it is a relation that `charm`
+    provides or requires.
+
+    Args:
+        charm: a `CharmBase` object to scan for the matching relation.
+        relation_name: the name of the relation to be verified.
+        expected_relation_interface: the interface name to be matched by the
+            relation named `relation_name`.
+        expected_relation_role: whether the `relation_name` must be either
+            provided or required by `charm`.
+    """
+    if relation_name not in charm.meta.relations:
+        raise RelationNotFoundError(relation_name)
+
+    relation = charm.meta.relations[relation_name]
+
+    actual_relation_interface = relation.interface_name
+    if actual_relation_interface != expected_relation_interface:
+        raise RelationInterfaceMismatchError(
+            relation_name, expected_relation_interface, actual_relation_interface
+        )
+
+    if expected_relation_role == RelationRole.provides:
+        if relation_name not in charm.meta.provides:
+            raise RelationRoleMismatchError(
+                relation_name, RelationRole.provides, RelationRole.requires
+            )
+    elif expected_relation_role == RelationRole.requires:
+        if relation_name not in charm.meta.requires:
+            raise RelationRoleMismatchError(
+                relation_name, RelationRole.requires, RelationRole.provides
+            )
+    else:
+        raise Exception("Unexpected RelationDirection: {}".format(expected_relation_role))
 
 
 class SourceFieldsMissingError(Exception):
@@ -58,32 +185,30 @@ class GrafanaSourceEvents(ObjectEvents):
     sources_to_delete_changed = EventSource(GrafanaSourcesChanged)
 
 
-class GrafanaSourceConsumer(Object):
-    """A consumer object for Grafana datasources."""
+class GrafanaSourceProvider(Object):
+    """A provider object for Grafana datasources."""
 
     _stored = StoredState()
 
     def __init__(
         self,
         charm: CharmBase,
-        name: str,
         refresh_event: CharmEvents,
+        relation_name: str = DEFAULT_RELATION_NAME,
         source_type: Optional[str] = "prometheus",
         source_port: Optional[str] = "9090",
     ) -> None:
         """Construct a Grafana charm client.
 
-        The :class:`GrafanaSourceConsumer` object provides an interface
+        The :class:`GrafanaSourceProvider` object provides an interface
         to Grafana. This interface supports providing additional
         sources for Grafana to monitor. For example, if a charm
         exposes some metrics which are consumable by an ingestor
         (such as Prometheus), then an additional source can be added
-        by instantiating a :class:`GrafanaSourceConsumer` object and
+        by instantiating a :class:`GrafanaSourceProvider` object and
         adding its datasources as follows:
 
-            self.grafana = GrafanaSourceConsumer(
-                self, "grafana-datasource", {"grafana_datasource"}: ">=2.0"}
-            )
+            self.grafana = GrafanaSourceProvider(self)
             self.grafana.add_source(
                 address=<address>,
                 port=<port>
@@ -91,38 +216,46 @@ class GrafanaSourceConsumer(Object):
 
         Args:
             charm: a :class:`CharmBase` object which manages this
-                :class:`GrafanaSourceConsumer` object. Generally this is
+                :class:`GrafanaSourceProvider` object. Generally this is
                 `self` in the instantiating class.
-            name: a :string: name of the relation between `charm`
-                the Grafana charmed service.
+            relation_name: string name of the relation that is provides the
+                Grafana source service. It is strongly advised not to change
+                the default, so that people deploying your charm will have a
+                consistent experience with all other charms that provide
+                Grafana datasources.
             refresh_event: a :class:`CharmEvents` event on which the IP
                 address should be refreshed in case of pod or
                 machine/VM restart.
             source_type: an optional (default `prometheus`) source type
-                required for Grafana configuration
+                required for Grafana configuration. The value must match
+                the DataSource type from the Grafana perspective.
             source_port: an optional (default `9090`) source port
-                required for Grafana configuration
+                required for Grafana configuration.
         """
-        super().__init__(charm, name)
-        self.charm = charm
-        self.name = name
-        events = self.charm.on[name]
+        _validate_relation_by_interface_and_direction(
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
+        )
+
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        events = self._charm.on[relation_name]
 
         self._source_type = source_type
         self._source_port = source_port
 
         self.framework.observe(events.relation_joined, self._set_sources)
-        self.framework.observe(refresh_event, self._set_unit_ip)
+        self.framework.observe(refresh_event, self._set_unit_ip)  # type: ignore[arg-type]
 
     def _set_sources(self, event: RelationJoinedEvent):
-        """Inform the provider about the source configuration."""
-        self._set_unit_ip(event)
+        """Inform the consumer about the source configuration."""
+        self._set_unit_ip(event)  # type: ignore[arg-type]
 
-        if not self.charm.unit.is_leader():
+        if not self._charm.unit.is_leader():
             return
 
         logger.debug("Setting Grafana data sources: %s", self._scrape_data)
-        event.relation.data[self.charm.app]["grafana_source_data"] = json.dumps(self._scrape_data)
+        event.relation.data[self._charm.app]["grafana_source_data"] = json.dumps(self._scrape_data)
 
     @property
     def _scrape_data(self) -> Dict:
@@ -132,9 +265,9 @@ class GrafanaSourceConsumer(Object):
             Source configuration data for Grafana.
         """
         data = {
-            "model": str(self.charm.model.name),
-            "model_uuid": str(self.charm.model.uuid),
-            "application": str(self.charm.model.app.name),
+            "model": str(self._charm.model.name),
+            "model_uuid": str(self._charm.model.uuid),
+            "application": str(self._charm.model.app.name),
             "type": self._source_type,
         }
         return data
@@ -142,35 +275,42 @@ class GrafanaSourceConsumer(Object):
     def _set_unit_ip(self, event: CharmEvents):
         """Set unit host address.
 
-        Each time a consumer charm container is restarted it updates its own host address in the
-        unit relation data for the Prometheus provider.
+        Each time a provider charm container is restarted it updates its own host address in the
+        unit relation data for the Prometheus consumer.
         """
-        for relation in self.charm.model.relations[self.name]:
-            relation.data[self.charm.unit]["grafana_source_host"] = "{}:{}".format(
-                str(self.charm.model.get_binding(relation).network.bind_address),
+        for relation in self._charm.model.relations[self._relation_name]:
+            relation.data[self._charm.unit]["grafana_source_host"] = "{}:{}".format(
+                str(self._charm.model.get_binding(relation).network.bind_address),
                 self._source_port,
             )
 
 
-class GrafanaSourceProvider(Object):
-    """A provider object for working with Grafana datasources."""
+class GrafanaSourceConsumer(Object):
+    """A consumer object for working with Grafana datasources."""
 
     on = GrafanaSourceEvents()
     _stored = StoredState()
 
-    def __init__(self, charm: CharmBase, name: str) -> None:
-        """A Grafana based Monitoring service consumer.
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """A Grafana based Monitoring service consumer, i.e., the charm that uses a datasource.
 
         Args:
             charm: a :class:`CharmBase` instance that manages this
                 instance of the Grafana source service.
-            name: string name of the relation that is provides the
-                Grafana source service.
+            relation_name: string name of the relation that is provides the
+                Grafana source service. It is strongly advised not to change
+                the default, so that people deploying your charm will have a
+                consistent experience with all other charms that provide
+                Grafana datasources.
         """
-        super().__init__(charm, name)
-        self.name = name
-        self.charm = charm
-        events = self.charm.on[name]
+        _validate_relation_by_interface_and_direction(
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires
+        )
+
+        super().__init__(charm, relation_name)
+        self._relation_name = relation_name
+        self._charm = charm
+        events = self._charm.on[relation_name]
 
         self._stored.set_default(
             sources=dict(),
@@ -181,10 +321,10 @@ class GrafanaSourceProvider(Object):
         self.framework.observe(events.relation_departed, self._on_grafana_source_relation_departed)
 
     def _on_grafana_source_relation_changed(self, event: CharmEvents) -> None:
-        """Handle relation changes in related consumers.
+        """Handle relation changes in related providers.
 
-        If there are changes in relations between Grafana source providers
-        and consumers, this event handler (if the unit is the leader) will
+        If there are changes in relations between Grafana source consumers
+        and providers, this event handler (if the unit is the leader) will
         get data for an incoming grafana-source relation through a
         :class:`GrafanaSourcesChanged` event, and make the relation data
         is available in the app's datastore object. This data is set using
@@ -193,12 +333,12 @@ class GrafanaSourceProvider(Object):
         The Grafana charm can then respond to the event to update its
         configuration.
         """
-        if not self.charm.unit.is_leader():
+        if not self._charm.unit.is_leader():
             return
 
         sources = {}
 
-        for rel in self.charm.model.relations[self.name]:
+        for rel in self._charm.model.relations[self._relation_name]:
             source = self._get_source_config(rel)
             if source:
                 sources[rel.id] = source
@@ -208,7 +348,7 @@ class GrafanaSourceProvider(Object):
         self.on.sources_changed.emit()
 
     def _get_source_config(self, rel: Relation):
-        """Generate configuration from data stored in relation data by consumers."""
+        """Generate configuration from data stored in relation data by providers."""
         source_data = json.loads(rel.data[rel.app].get("grafana_source_data", "{}"))
         if not source_data:
             return
@@ -225,19 +365,19 @@ class GrafanaSourceProvider(Object):
 
             host_data = {
                 "unit": unit_name,
-                "source-name": unique_source_name,
-                "source-type": source_data["type"],
+                "source_name": unique_source_name,
+                "source_type": source_data["type"],
                 "url": "http://{}".format(host_addr),
             }
 
-            if host_data["source-name"] in self._stored.sources_to_delete:
-                self._stored.sources_to_delete.remove(host_data["source-name"])
+            if host_data["source_name"] in self._stored.sources_to_delete:
+                self._stored.sources_to_delete.remove(host_data["source_name"])
 
             data.append(host_data)
         return data
 
     def _relation_hosts(self, rel: Relation) -> Dict:
-        """Fetch host names and address of all consumer units for a single relation.
+        """Fetch host names and address of all provider units for a single relation.
 
         Args:
             rel: An `ops.model.Relation` object for which the host name to
@@ -256,14 +396,14 @@ class GrafanaSourceProvider(Object):
         return hosts
 
     def _on_grafana_source_relation_departed(self, event: RelationDepartedEvent) -> None:
-        """Update job config when consumers depart.
+        """Update job config when providers depart.
 
-        When a Grafana source consumer departs, the configuration
-        for that consumer is removed from the list of sources jobs,
-        added to a list of sources to remove, and other consumers
+        When a Grafana source provider departs, the configuration
+        for that provider is removed from the list of sources jobs,
+        added to a list of sources to remove, and other providers
         are informed through a :class:`GrafanaSourcesChanged` event.
         """
-        if not self.charm.unit.is_leader():
+        if not self._charm.unit.is_leader():
             return
 
         self._remove_source_from_datastore(event)
@@ -281,7 +421,7 @@ class GrafanaSourceProvider(Object):
             if event.unit:
                 # Remove one unit only
                 dead_unit = [s for s in removed_source if s["unit"] == event.unit.name][0]
-                self._remove_source(dead_unit["source-name"])
+                self._remove_source(dead_unit["source_name"])
 
                 # Re-update the list of stored sources
                 self._stored.sources[rel_id] = [
@@ -289,7 +429,7 @@ class GrafanaSourceProvider(Object):
                 ]
             else:
                 for host in removed_source:
-                    self._remove_source(host["source-name"])
+                    self._remove_source(host["source_name"])
 
             self.on.sources_to_delete_changed.emit()
 
@@ -297,28 +437,29 @@ class GrafanaSourceProvider(Object):
         """Remove a datasource by name."""
         self._stored.sources_to_delete.add(source_name)
 
+    def upgrade_keys(self) -> None:
+        """On upgrade, ensure stored data maintains compatibility."""
+        # self._stored.sources may have hyphens instead of underscores in key names.
+        # Make sure they reconcile.
+        sources = _type_convert_stored(self._stored.sources)
+        for rel_id in sources.keys():
+            for i in range(len(sources[rel_id])):
+                sources[rel_id][i].update(
+                    {k.replace("-", "_"): v for k, v in sources[rel_id][i].items()}
+                )
+
+        self._stored.sources = sources
+
     @property
     def sources(self) -> List[dict]:
-        """Returns an array of sources the source_provider knows about."""
+        """Returns an array of sources the source_consumer knows about."""
         sources = []
         for source in self._stored.sources.values():
-            sources.extend([host for host in source])
+            sources.extend([host for host in _type_convert_stored(source)])
 
         return sources
-
-    def update_port(self, relation_name: str, port: int) -> None:
-        """Updates the port grafana-k8s is listening on."""
-        if self.charm.unit.is_leader():
-            for relation in self.charm.model.relations[relation_name]:
-                logger.debug("Setting grafana-k8s address data for relation", relation)
-                if str(port) != relation.data[self.charm.app].get("port", None):
-                    relation.data[self.charm.app]["port"] = str(port)
 
     @property
     def sources_to_delete(self) -> List[str]:
         """Returns an array of source names which have been removed."""
-        sources_to_delete = []
-        for source in self._stored.sources_to_delete:
-            sources_to_delete.append(source)
-
-        return sources_to_delete
+        return [_type_convert_stored(source) for source in self._stored.sources_to_delete]

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1482,7 +1482,7 @@ class LogProxyConsumer(ConsumerBase):
     def _get_container_name(self, container_name: Optional[str] = "") -> str:
         """Gets a container_name.
 
-        If there is more than one container in the Pod a `PromtailDigestError` is emitted.
+        If there is more than one container in the Pod a `ContainerNotFoundError` is raised.
 
         Args:
             container_name: The container name.

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -204,21 +204,49 @@ Adopting this object in a Charmed Operator consist of two steps:
    For example:
 
    ```python
-   from charms.loki_k8s.v0.log_proxy import LogProxyConsumer, PromtailDigestError
+   from charms.loki_k8s.v0.log_proxy import LogProxyConsumer
 
    ...
 
        def __init__(self, *args):
            ...
-           try:
-               self._log_proxy = LogProxyConsumer(
-                   charm=self, log_files=LOG_FILES, container_name=PEER, enable_syslog=True
-               )
-           except PromtailDigestError as e:
-               msg = str(e)
+           self._log_proxy = LogProxyConsumer(
+               charm=self, log_files=LOG_FILES, container_name=PEER, enable_syslog=True
+           )
+
+           self.framework.observe(
+               self._loki_consumer.on.promtail_digest_error,
+               self._promtail_error,
+           )
+
+           def _promtail_error(self, event):
                logger.error(msg)
-               self.unit.status = BlockedStatus(msg)
+               self.unit.status = BlockedStatus(event.message)
    ```
+
+   Any time the relation between a provider charm and a LogProxy consumer charm is
+   established, a `LogProxyEndpointJoined` event is fired. In the consumer side is it
+   possible to observe this event with:
+
+   ```python
+
+   self.framework.observe(
+       self._log_proxy.on.log_proxy_endpoint_joined,
+       self._on_log_proxy_endpoint_joined,
+   )
+   ```
+
+   Any time there are departures in relations between the consumer charm and the provider
+   the consumer charm is informed, through a `LogProxyEndpointDeparted` event, for instance:
+
+   ```python
+   self.framework.observe(
+       self._log_proxy.on.log_proxy_endpoint_departed,
+       self._on_log_proxy_endpoint_departed,
+   )
+   ```
+
+   The consumer charm can then choose to update its configuration in both situations.
 
    Note that:
 
@@ -280,8 +308,19 @@ The object can raise a `PromtailDigestError` when:
 - No `container_name` parameter has been specified and the Pod has more than 1 container.
 - The sha256 sum mismatch for promtail binary.
 
-that's why in the above example, the instantiation is made in a `try/except` block
-to handle these situations conveniently.
+These can be monitored via the PromtailDigestError events via:
+
+```python
+   self.framework.observe(
+       self._loki_consumer.on.promtail_digest_error,
+       self._promtail_error,
+   )
+
+   def _promtail_error(self, event):
+       logger.error(msg)
+       self.unit.status = BlockedStatus(event.message)
+    )
+```
 
 ## Alerting Rules
 
@@ -381,7 +420,9 @@ from zipfile import ZipFile
 import yaml
 from ops.charm import (
     CharmBase,
+    HookEvent,
     RelationChangedEvent,
+    RelationCreatedEvent,
     RelationDepartedEvent,
     RelationEvent,
     RelationRole,
@@ -395,7 +436,7 @@ from ops.framework import (
     StoredList,
     StoredState,
 )
-from ops.model import ModelError, Relation
+from ops.model import Container, ModelError, Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "bf76f23cdd03464b877c52bd1d2f563e"
@@ -587,7 +628,7 @@ class JujuTopology:
         self.charm_name = charm_name
 
     @classmethod
-    def from_charm(cls, charm):
+    def from_charm(cls, charm: CharmBase) -> "JujuTopology":
         """Factory method for creating the topology dataclass from a given charm."""
         return cls(
             model=charm.model.name,
@@ -597,7 +638,7 @@ class JujuTopology:
         )
 
     @classmethod
-    def from_relation_data(cls, data):
+    def from_relation_data(cls, data: dict) -> "JujuTopology":
         """Factory method for creating the topology dataclass from a relation data dict."""
         return cls(
             model=data["model"],
@@ -612,12 +653,12 @@ class JujuTopology:
         return "{}_{}_{}".format(self.model, self.model_uuid, self.application)
 
     @property
-    def short_model_uuid(self):
+    def short_model_uuid(self) -> str:
         """Obtain the short form of the model uuid."""
         return self.model_uuid[:7]
 
     @property
-    def scrape_identifier(self):
+    def scrape_identifier(self) -> str:
         """Format the topology information into a scrape identifier."""
         return "juju_{}_{}_{}".format(
             self.model,
@@ -632,7 +673,7 @@ class JujuTopology:
             self.model, self.model_uuid, self.application
         )
 
-    def as_dict(self, short_uuid=False) -> dict:
+    def as_dict(self, short_uuid: bool = False) -> dict:
         """Format the topology information into a dict."""
         return {
             "model": self.model,
@@ -641,7 +682,7 @@ class JujuTopology:
             "charm_name": self.charm_name,
         }
 
-    def as_dict_with_logql_labels(self):
+    def as_dict_with_logql_labels(self) -> dict:
         """Format the topology information into a dict with keys having 'juju_' as prefix."""
         return {
             "juju_model": self.model,
@@ -650,7 +691,7 @@ class JujuTopology:
             "juju_charm": self.charm_name,
         }
 
-    def render(self, template: str):
+    def render(self, template: str) -> str:
         """Render a juju-topology template string with topology info."""
         return template.replace("%%juju_topology%%", self.logql_labels)
 
@@ -822,7 +863,7 @@ class LokiPushApiAlertRulesError(EventBase):
         super().__init__(handle)
         self.message = message
 
-    def snapshot(self):
+    def snapshot(self) -> dict:
         """Save message information."""
         return {"message": self.message}
 
@@ -839,7 +880,7 @@ class LokiPushApiEndpointJoined(EventBase):
     """Event emitted when Loki joined."""
 
 
-class LoggingEvents(ObjectEvents):
+class LokiPushApiEvents(ObjectEvents):
     """Event descriptor for events raised by `LokiPushApiProvider`."""
 
     loki_push_api_alert_rules_error = EventSource(LokiPushApiAlertRulesError)
@@ -904,7 +945,7 @@ class LokiPushApiProvider(RelationManagerBase):
         self.framework.observe(events.relation_changed, self._on_logging_relation_changed)
         self.framework.observe(events.relation_departed, self._on_logging_relation_departed)
 
-    def _on_logging_relation_changed(self, event):
+    def _on_logging_relation_changed(self, event: HookEvent):
         """Handle changes in related consumers.
 
         Anytime there are changes in the relation between Loki
@@ -943,7 +984,7 @@ class LokiPushApiProvider(RelationManagerBase):
             self._remove_alert_rules_files(self.container)
             self._generate_alert_rules_files(self.container)
 
-    def _on_logging_relation_departed(self, event):
+    def _on_logging_relation_departed(self, event: RelationDepartedEvent):
         """Removes alert rules files when consumer charms left the relation with Loki.
 
         Args:
@@ -977,7 +1018,7 @@ class LokiPushApiProvider(RelationManagerBase):
             return str(bind_address)
         return ""
 
-    def _remove_alert_rules_files(self, container) -> None:
+    def _remove_alert_rules_files(self, container: Container) -> None:
         """Remove alert rules files from workload container.
 
         Args:
@@ -989,7 +1030,7 @@ class LokiPushApiProvider(RelationManagerBase):
         # we should create it again.
         os.makedirs(self._rules_dir, exist_ok=True)
 
-    def _generate_alert_rules_files(self, container) -> None:
+    def _generate_alert_rules_files(self, container: Container) -> None:
         """Generate and upload alert rules files.
 
         Args:
@@ -1079,7 +1120,7 @@ class ConsumerBase(RelationManagerBase):
         self._alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
         self.topology = JujuTopology.from_charm(charm)
 
-    def _handle_alert_rules(self, relation):
+    def _handle_alert_rules(self, relation: Relation):
         if self._charm.unit.is_leader():
             alert_groups, invalid_files = load_alert_rules_from_dir(
                 self._alert_rules_path,
@@ -1095,7 +1136,7 @@ class ConsumerBase(RelationManagerBase):
             relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
             relation.data[self._charm.app]["alert_rules"] = json.dumps({"groups": alert_groups})
 
-    def _check_alert_rules(self, alert_groups, invalid_files) -> str:
+    def _check_alert_rules(self, alert_groups: List, invalid_files: List) -> str:
         """Check alert rules.
 
         Args:
@@ -1125,7 +1166,7 @@ class ConsumerBase(RelationManagerBase):
 class LokiPushApiConsumer(ConsumerBase):
     """Loki Consumer class."""
 
-    on = LoggingEvents()
+    on = LokiPushApiEvents()
     _stored = StoredState()
 
     def __init__(
@@ -1188,7 +1229,7 @@ class LokiPushApiConsumer(ConsumerBase):
         self.framework.observe(events.relation_changed, self._on_logging_relation_changed)
         self.framework.observe(events.relation_departed, self._on_logging_relation_departed)
 
-    def _on_logging_relation_changed(self, event):
+    def _on_logging_relation_changed(self, event: HookEvent):
         """Handle changes in related consumers.
 
         Anytime there are changes in the relation between Loki
@@ -1219,7 +1260,7 @@ class LokiPushApiConsumer(ConsumerBase):
         self._handle_alert_rules(relation)
         self.on.loki_push_api_endpoint_joined.emit()
 
-    def _on_logging_relation_departed(self, event):
+    def _on_logging_relation_departed(self, event: RelationDepartedEvent):
         """Handle departures in related providers.
 
         Anytime there are departures in relations between the consumer charm and Loki
@@ -1244,8 +1285,50 @@ class LokiPushApiConsumer(ConsumerBase):
         ]
 
 
-class PromtailDigestError(Exception):
-    """Raised if there is an error with Promtail binary file."""
+class ContainerNotFoundError(Exception):
+    """Raised if there is no container with the given name or the name is ambiguous."""
+
+    def __init__(self):
+        msg = (
+            "No 'container_name' parameter has been specified; since this Charmed Operator"
+            " is not running exactly one container, it must be specified which container"
+            " to get logs from."
+        )
+        self.message = msg
+
+        super().__init__(self.message)
+
+
+class PromtailDigestError(EventBase):
+    """Event emitted when there is an error with the Promtail binary file."""
+
+    def __init__(self, handle, message):
+        super().__init__(handle)
+        self.message = message
+
+    def snapshot(self):
+        """Save message information."""
+        return {"message": self.message}
+
+    def restore(self, snapshot):
+        """Restore message information."""
+        self.message = snapshot["message"]
+
+
+class LogProxyEndpointDeparted(EventBase):
+    """Event emitted when a Log Proxy has departed."""
+
+
+class LogProxyEndpointJoined(EventBase):
+    """Event emitted when a Log Proxy joins."""
+
+
+class LogProxyEvents(ObjectEvents):
+    """Event descriptor for events raised by `LokiPushApiProvider`."""
+
+    promtail_digest_error = EventSource(PromtailDigestError)
+    log_proxy_endpoint_departed = EventSource(LogProxyEndpointDeparted)
+    log_proxy_endpoint_joined = EventSource(LogProxyEndpointJoined)
 
 
 class LogProxyConsumer(ConsumerBase):
@@ -1289,6 +1372,7 @@ class LogProxyConsumer(ConsumerBase):
             role.
     """
 
+    on = LogProxyEvents()
     _stored = StoredState()
 
     def __init__(
@@ -1323,14 +1407,14 @@ class LogProxyConsumer(ConsumerBase):
             self._charm.on.log_proxy_relation_departed, self._on_log_proxy_relation_departed
         )
 
-    def _on_log_proxy_relation_created(self, event):
+    def _on_log_proxy_relation_created(self, _: RelationCreatedEvent):
         """Event handler for the `log_proxy_relation_created`."""
         self._create_directories()
         self._container.push(
             WORKLOAD_CONFIG_PATH, yaml.safe_dump(self._initial_config), make_dirs=True
         )
 
-    def _on_log_proxy_relation_changed(self, event):
+    def _on_log_proxy_relation_changed(self, event: RelationChangedEvent):
         """Event handler for the `log_proxy_relation_changed`.
 
         Args:
@@ -1340,16 +1424,17 @@ class LogProxyConsumer(ConsumerBase):
             try:
                 self._obtain_promtail(event)
             except HTTPError as e:
-                msg = "Promtail binary couldn't be download - {}".format(str(e))
+                msg = "Promtail binary couldn't be downloaded - {}".format(str(e))
                 logger.warning(msg)
-                raise PromtailDigestError(msg)
+                self.on.promtail_digest_error.emit(msg)
             else:
                 self._update_config(event)
                 self._update_agents_list(event)
                 self._add_pebble_layer()
                 self._container.restart(WORKLOAD_SERVICE_NAME)
+                self.on.log_proxy_endpoint_joined.emit()
 
-    def _on_log_proxy_relation_departed(self, event):
+    def _on_log_proxy_relation_departed(self, event: RelationDepartedEvent):
         """Event handler for the `log_proxy_relation_departed`.
 
         Args:
@@ -1363,10 +1448,12 @@ class LogProxyConsumer(ConsumerBase):
         else:
             self._container.restart(WORKLOAD_SERVICE_NAME)
 
-    def _get_container(self, container_name):
+        self.on.log_proxy_endpoint_departed.emit()
+
+    def _get_container(self, container_name: Optional[str] = "") -> Container:
         """Gets a single container by name or using the only container running in the Pod.
 
-        If there is more than one container in the Pod a `PromtailDigestError` is raised.
+        If there is more than one container in the Pod a `PromtailDigestError` is emitted.
 
         Args:
             container_name: The container name.
@@ -1375,33 +1462,27 @@ class LogProxyConsumer(ConsumerBase):
             container: a `ops.model.Container` object representing the container.
 
         Raises:
-            PromtailDigestError if no `container_name` is passed and there is more than one
-                container in the Pod.
+            ContainerNotFoundError if no container_name was specified
         """
-        if container_name is not None:
+        if container_name:
             try:
                 return self._charm.unit.get_container(container_name)
             except ModelError as e:
                 msg = str(e)
                 logger.warning(msg)
-                raise PromtailDigestError(msg)
+                self.on.promtail_digest_error.emit(msg)
         else:
             containers = dict(self._charm.model.unit.containers)
 
             if len(containers) == 1:
                 return self._charm.unit.get_container([*containers].pop())
 
-            msg = (
-                "No 'container_name' parameter has been specified; since this Charmed Operator"
-                " is not running exactly one container, it must be specified which container"
-                " to get logs from."
-            )
-            raise PromtailDigestError(msg)
+            raise ContainerNotFoundError
 
-    def _get_container_name(self, container_name):
+    def _get_container_name(self, container_name: Optional[str] = "") -> str:
         """Gets a container_name.
 
-        If there is more than one container in the Pod a `PromtailDigestError` is raised.
+        If there is more than one container in the Pod a `PromtailDigestError` is emitted.
 
         Args:
             container_name: The container name.
@@ -1410,22 +1491,16 @@ class LogProxyConsumer(ConsumerBase):
             container_name: a string representing the container_name.
 
         Raises:
-            PromtailDigestError if no `container_name` is passed and there is more than one
-                container in the Pod.
+            ContainerNotFoundError if no container_name was specified
         """
-        if container_name is not None:
+        if container_name:
             return container_name
 
         containers = dict(self._charm.model.unit.containers)
         if len(containers) == 1:
             return "".join(list(containers.keys()))
 
-        msg = (
-            "No 'container_name' parameter has been specified; since this charmed operator"
-            " is not running exactly one container, it must be specified which container"
-            " to get logs from."
-        )
-        raise PromtailDigestError(msg)
+        raise ContainerNotFoundError
 
     def _add_pebble_layer(self):
         """Adds Pebble layer that manages Promtail service in Workload container."""
@@ -1448,7 +1523,7 @@ class LogProxyConsumer(ConsumerBase):
         self._container.make_dir(path=WORKLOAD_BINARY_DIR, make_parents=True)
         self._container.make_dir(path=WORKLOAD_CONFIG_DIR, make_parents=True)
 
-    def _obtain_promtail(self, event) -> None:
+    def _obtain_promtail(self, event: RelationChangedEvent) -> None:
         """Obtain promtail binary from an attached resource or download it."""
         if self._is_promtail_attached():
             return
@@ -1535,7 +1610,7 @@ class LogProxyConsumer(ConsumerBase):
         """
         return True if Path(BINARY_PATH).is_file() else False
 
-    def _download_and_push_promtail_to_workload(self, event) -> None:
+    def _download_and_push_promtail_to_workload(self, event: RelationChangedEvent) -> None:
         """Downloads a Promtail zip file and pushes the binary to the workload."""
         url = json.loads(event.relation.data[event.app].get("data"))["promtail_binary_zip_url"]
 
@@ -1553,7 +1628,7 @@ class LogProxyConsumer(ConsumerBase):
 
         self._push_binary_to_workload()
 
-    def _update_agents_list(self, event):
+    def _update_agents_list(self, event: RelationChangedEvent):
         """Updates the active Grafana agents list.
 
         Args:
@@ -1569,7 +1644,7 @@ class LogProxyConsumer(ConsumerBase):
             agent_url = grafana_agents.pop(str(event.app))
             self._stored.grafana_agents = json.dumps(grafana_agents)
 
-    def _update_config(self, event):
+    def _update_config(self, event: RelationEvent):
         """Updates the config file for Promtail and upload it to the side-car container.
 
         Args:
@@ -1598,7 +1673,7 @@ class LogProxyConsumer(ConsumerBase):
         current_config = yaml.safe_load(raw_current)
         return current_config
 
-    def _build_config_file(self, event) -> str:
+    def _build_config_file(self, event: RelationEvent) -> str:
         """Generates config file str based on the event received.
 
         Args:
@@ -1649,7 +1724,7 @@ class LogProxyConsumer(ConsumerBase):
 
         return current_config
 
-    def _remove_client(self, current_config, agent_url) -> dict:
+    def _remove_client(self, current_config: dict, agent_url: str) -> dict:
         """Updates Promtail's current configuration by removing a Grafana Agent URL.
 
         Args:
@@ -1749,13 +1824,13 @@ class LogProxyConsumer(ConsumerBase):
         return static_configs
 
     @property
-    def syslog_port(self):
+    def syslog_port(self) -> str:
         """Gets the port on which promtail is listening for syslog.
 
         Returns:
-            A string representing the port
+            A str representing the port
         """
-        return self._syslog_port
+        return str(self._syslog_port)
 
     @property
     def rsyslog_config(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ follow_imports = "skip"
 module = ["charms.prometheus_k8s.*"]
 follow_imports = "silent"
 
+[[tool.mypy.overrides]]
+module = ["charms.grafana_k8s.*"]
+follow_imports = "silent"
+warn_unused_ignores = false
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,7 @@ import textwrap
 
 import yaml
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
-from charms.grafana_k8s.v0.grafana_source import GrafanaSourceConsumer
+from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
 from ops.charm import CharmBase
 from ops.framework import StoredState
@@ -49,9 +49,8 @@ class LokiOperatorCharm(CharmBase):
         self._container = self.unit.get_container(self._name)
         self._stored.set_default(k8s_service_patched=False, config="")
         self.alertmanager_consumer = AlertmanagerConsumer(self, relation_name="alertmanager")
-        self.grafana_source_consumer = GrafanaSourceConsumer(
+        self.grafana_source_provider = GrafanaSourceProvider(
             charm=self,
-            name="grafana-source",
             refresh_event=self.on.loki_pebble_ready,
             source_type="loki",
             source_port=str(self._port),

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -118,7 +118,7 @@ class TestLokiPushApiConsumer(unittest.TestCase):
             loki_push_api,
         )
 
-    @patch("charms.loki_k8s.v0.loki_push_api.LoggingEvents.loki_push_api_endpoint_joined")
+    @patch("charms.loki_k8s.v0.loki_push_api.LokiPushApiEvents.loki_push_api_endpoint_joined")
     def test__on_upgrade_charm_endpoint_joined_event_fired_for_leader(self, mock_events):
         self.harness.set_leader(True)
 
@@ -131,7 +131,7 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         )
         mock_events.emit.assert_called_once()
 
-    @patch("charms.loki_k8s.v0.loki_push_api.LoggingEvents.loki_push_api_endpoint_joined")
+    @patch("charms.loki_k8s.v0.loki_push_api.LokiPushApiEvents.loki_push_api_endpoint_joined")
     def test__on_upgrade_charm_endpoint_joined_event_fired_for_follower(self, mock_events):
         self.harness.set_leader(False)
 


### PR DESCRIPTION
Send events like LokiPushApi already does so the UX is the same.
    
Instead of raising exceptions for everything in the LogProxy code, forcing consumers to catch them to set state, fire back an event if something happens with the Promtail Binary.
    
Only send a new `ContainerNotFound` Exception if the container name is unset or ambiguous enough that we can't suss one out.
    
Add a bunch of type hints.
    
Update tests.
    
Closes #70 
Closes #69 

Really depends on #67, but the changes on top of that are reasonably small