### PR TITLE
Streamline AlertRules class from prometheus

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -368,12 +368,11 @@ key.
 import json
 import logging
 import os
-from collections import defaultdict
 from copy import deepcopy
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError
 from urllib.request import urlopen
 from zipfile import ZipFile
@@ -405,7 +404,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 logger = logging.getLogger(__name__)
 
@@ -655,108 +654,239 @@ class JujuTopology:
         return template.replace("%%juju_topology%%", self.logql_labels)
 
 
-def load_alert_rule_from_file(
-    path: Path, topology: JujuTopology, allow_free_standing
-) -> Optional[dict]:
-    """Load alert rule from a rules file.
+class InvalidAlertRulePathError(Exception):
+    """Raised if the alert rules folder cannot be found or is otherwise invalid."""
+
+    def __init__(
+        self,
+        alert_rules_absolute_path: Path,
+        message: str,
+    ):
+        self.alert_rules_absolute_path = alert_rules_absolute_path
+        self.message = message
+
+        super().__init__(self.message)
+
+
+def _is_official_alert_rule_format(rules_dict: dict) -> bool:
+    """Are alert rules in the upstream format as supported by Loki.
+
+    Alert rules in dictionary format are in "official" form if they
+    contain a "groups" key, since this implies they contain a list of
+    alert rule groups.
 
     Args:
-        path: path to a *.rule file with a single rule ("groups" super section omitted).
-        topology: a `JujuTopology` instance.
-        allow_free_standing: whether or not to reject files that do not have the special
-          %%juju_topology%% template variable, which is the case for free-standing rules.
-    """
-    with path.open() as rule_file:
-        # Load a list of rules from file then add labels and filters
-        try:
-            rule = yaml.safe_load(rule_file)
-            if not _is_valid_rule(rule, allow_free_standing):
-                return None
-        except Exception as e:
-            logger.error("Failed to read alert rules from %s: %s", path.name, e)
-            return None
-        else:
-            # add "juju_" topology labels
-            if "labels" not in rule:
-                rule["labels"] = {}
-            rule["labels"].update(topology.as_dict_with_logql_labels())
-
-            # insert juju topology filters into a Loki alert rule
-            rule["expr"] = topology.render(rule["expr"])
-
-            return rule
-
-
-def load_alert_rules_from_dir(
-    dir_path: str,
-    topology: JujuTopology,
-    *,
-    recursive: bool = False,
-    allow_free_standing: bool = False,
-) -> Tuple[List[dict], List[Path]]:
-    """Load alert rules from rule files.
-
-    All rules from files for the same directory are loaded into a single
-    group. The generated name of this group includes juju topology.
-    By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
-
-    Args:
-        dir_path: directory containing *.rule files (alert rules without groups).
-        topology: a `JujuTopology` instance.
-        recursive: flag indicating whether to scan for rule files recursively.
-        allow_free_standing: whether or not to reject files that do not have the special
-          %%juju_topology%% template variable, which is the case for free-standing rules.
+        rules_dict: a set of alert rules in Python dictionary format
 
     Returns:
-        A 2-tuple consisting:
-        - a list of prometheus alert rule groups
-        - a list of invalid rules files
+        True if alert rules are in official Loki file format.
     """
-    alerts = defaultdict(list)
+    return "groups" in rules_dict
 
-    def _group_name(path) -> str:
+
+def _is_single_alert_rule_format(rules_dict: dict) -> bool:
+    """Are alert rules in single rule format.
+
+    The Loki charm library supports reading of alert rules in a
+    custom format that consists of a single alert rule per file. This
+    does not conform to the official Loki alert rule file format
+    which requires that each alert rules file consists of a list of
+    alert rule groups and each group consists of a list of alert
+    rules.
+
+    Alert rules in dictionary form are considered to be in single rule
+    format if in the least it contains two keys corresponding to the
+    alert rule name and alert expression.
+
+    Returns:
+        True if alert rule is in single rule file format.
+    """
+    # one alert rule per file
+    return set(rules_dict) >= {"alert", "expr"}
+
+
+class AlertRules:
+    """Utility class for amalgamating Loki alert rule files and injecting juju topology.
+
+    An `AlertRules` object supports aggregating alert rules from files and directories in both
+    official and single rule file formats using the `add_path()` method. All the alert rules
+    read are annotated with Juju topology labels and amalgamated into a single data structure
+    in the form of a Python dictionary using the `as_dict()` method. Such a dictionary can be
+    easily dumped into JSON format and exchanged over relation data. The dictionary can also
+    be dumped into YAML format and written directly into an alert rules file that is read by
+    Loki. Note that multiple `AlertRules` objects must not be written into the same file,
+    since Loki allows only a single list of alert rule groups per alert rules file.
+
+    The official Loki format is a YAML file conforming to the Loki documentation
+    (https://grafana.com/docs/loki/latest/api/#list-rule-groups).
+    The custom single rule format is a subsection of the official YAML, having a single alert
+    rule, effectively "one alert per file".
+    """
+
+    # This class uses the following terminology for the various parts of a rule file:
+    # - alert rules file: the entire groups[] yaml, including the "groups:" key.
+    # - alert groups (plural): the list of groups[] (a list, i.e. no "groups:" key) - it is a list
+    #   of dictionaries that have the "name" and "rules" keys.
+    # - alert group (singular): a single dictionary that has the "name" and "rules" keys.
+    # - alert rules (plural): all the alerts in a given alert group - a list of dictionaries with
+    #   the "alert" and "expr" keys.
+    # - alert rule (singular): a single dictionary that has the "alert" and "expr" keys.
+
+    def __init__(self, topology: JujuTopology):
+        """Build and alert rule object.
+
+        Args:
+            topology: a `JujuTopology` instance that is used to annotate all alert rules.
+        """
+        self.topology = topology
+        self.alert_groups = []  # type: List[dict]
+
+    def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
+        """Read a rules file from path, injecting juju topology.
+
+        Args:
+            root_path: full path to the root rules folder (used only for generating group name)
+            file_path: full path to a *.rule file.
+
+        Returns:
+            A list of dictionaries representing the rules file, if file is valid (the structure is
+            formed by `yaml.safe_load` of the file); an empty list otherwise.
+        """
+        with file_path.open() as rf:
+            # Load a list of rules from file then add labels and filters
+            try:
+                rule_file = yaml.safe_load(rf)
+
+            except Exception as e:
+                logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
+                return []
+
+            if _is_official_alert_rule_format(rule_file):
+                alert_groups = rule_file["groups"]
+            elif _is_single_alert_rule_format(rule_file):
+                # convert to list of alert groups
+                # group name is made up from the file name
+                alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
+            else:
+                # invalid/unsupported
+                logger.error("Invalid rules file: %s", file_path.name)
+                return []
+
+            # update rules with additional metadata
+            for alert_group in alert_groups:
+                # update group name with topology and sub-path
+                alert_group["name"] = self._group_name(
+                    str(root_path),
+                    str(file_path),
+                    alert_group["name"],
+                )
+
+                # add "juju_" topology labels
+                for alert_rule in alert_group["rules"]:
+                    if "labels" not in alert_rule:
+                        alert_rule["labels"] = {}
+                    alert_rule["labels"].update(self.topology.as_dict_with_logql_labels())
+
+                    # insert juju topology filters into a prometheus alert rule
+                    alert_rule["expr"] = self.topology.render(alert_rule["expr"])
+
+            return alert_groups
+
+    def _group_name(self, root_path: str, file_path: str, group_name: str) -> str:
         """Generate group name from path and topology.
 
         The group name is made up of the relative path between the root dir_path, the file path,
         and topology identifier.
 
         Args:
-            path: path to rule file.
+            root_path: path to the root rules dir.
+            file_path: path to rule file.
+            group_name: original group name to keep as part of the new augmented group name
+
+        Returns:
+            New group name, augmented by juju topology and relative path.
         """
-        relpath = os.path.relpath(os.path.dirname(path), dir_path)
+        rel_path = os.path.relpath(os.path.dirname(file_path), root_path)
+        rel_path = "" if rel_path == "." else rel_path.replace(os.path.sep, "_")
 
         # Generate group name:
         #  - name, from juju topology
         #  - suffix, from the relative path of the rule file;
-        return "{}_{}alerts".format(
-            topology.identifier, "" if relpath == "." else relpath.replace(os.path.sep, "_") + "_"
-        )
+        group_name_parts = [self.topology.identifier, rel_path, group_name, "alerts"]
+        # filter to remove empty strings
+        return "_".join(filter(None, group_name_parts))
 
-    invalid_files = []
-    for path in filter(Path.is_file, Path(dir_path).glob("**/*.rule" if recursive else "*.rule")):
-        rule = load_alert_rule_from_file(path, topology, allow_free_standing)
+    def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
+        """Read all rule files in a directory.
 
-        if rule:
-            logger.debug("Reading alert rule from %s", path)
-            alerts[_group_name(path)].append(rule)
+        All rules from files for the same directory are loaded into a single
+        group. The generated name of this group includes juju topology.
+        By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
+
+        Args:
+            dir_path: directory containing *.rule files (alert rules without groups).
+            recursive: flag indicating whether to scan for rule files recursively.
+
+        Returns:
+            a list of dictionaries representing prometheus alert rule groups, each dictionary
+            representing an alert group (structure determined by `yaml.safe_load`).
+        """
+        alert_groups = []  # type: List[dict]
+
+        # Gather all alerts into a list of groups
+        paths = dir_path.glob("**/*.rule" if recursive else "*.rule")
+        for file_path in filter(Path.is_file, paths):
+            alert_groups_from_file = self._from_file(dir_path, file_path)
+            if alert_groups_from_file:
+                logger.debug("Reading alert rule from %s", file_path)
+                alert_groups.extend(alert_groups_from_file)
+
+        return alert_groups
+
+    def add_path(self, path: str, *, recursive: bool = False):
+        """Add rules from a dir path.
+
+        All rules from files are aggregated into a data structure representing a single rule file.
+        All group names are augmented with juju topology.
+
+        Args:
+            path: either a rules file or a dir of rules files.
+            recursive: whether to read files recursively or not (no impact if `path` is a file).
+
+        Raises:
+            InvalidAlertRulePathError: if the provided path is invalid.
+        """
+        path = Path(path)  # type: Path
+        if path.is_dir():
+            self.alert_groups.extend(self._from_dir(path, recursive))
+        elif path.is_file():
+            self.alert_groups.extend(self._from_file(path.parent, path))
         else:
-            invalid_files.append(path)
+            logger.warning("path does not exist: %s", path)
 
-    # Gather all alerts into a list of groups since Prometheus
-    # requires alerts be part of some group
-    groups = [{"name": k, "rules": v} for k, v in alerts.items()]
-    return groups, invalid_files
+    def as_dict(self) -> dict:
+        """Return standard alert rules file in dict representation.
+
+        Returns:
+            a dictionary containing a single list of alert rule groups.
+            The list of alert rule groups is provided as value of the
+            "groups" dictionary key.
+        """
+        return {"groups": self.alert_groups} if self.alert_groups else {}
 
 
 def _resolve_dir_against_charm_path(charm: CharmBase, *path_elements: str) -> str:
     """Resolve the provided path items against the directory of the main file.
 
-    Look up the directory of the main .py file being executed. This is normally
+    Look up the directory of the `main.py` file being executed. This is normally
     going to be the charm.py file of the charm including this library. Then, resolve
-    the provided path elements and return its absolute path, without checking for existence or
-     validity.
+    the provided path elements and, if the result path exists and is a directory,
+    return its absolute path; otherwise, raise en exception.
+
+    Raises:
+        InvalidAlertRulePathError, if the path does not exist or is not a directory.
     """
-    charm_dir = Path(charm.charm_dir)
+    charm_dir = Path(str(charm.charm_dir))
     if not charm_dir.exists() or not charm_dir.is_dir():
         # Operator Framework does not currently expose a robust
         # way to determine the top level charm source directory
@@ -767,6 +897,12 @@ def _resolve_dir_against_charm_path(charm: CharmBase, *path_elements: str) -> st
         charm_dir = Path(os.getcwd())
 
     alerts_dir_path = charm_dir.absolute().joinpath(*path_elements)
+
+    if not alerts_dir_path.exists():
+        raise InvalidAlertRulePathError(alerts_dir_path, "directory does not exist")
+    if not alerts_dir_path.is_dir():
+        raise InvalidAlertRulePathError(alerts_dir_path, "is not a directory")
+
     return str(alerts_dir_path)
 
 
@@ -1070,58 +1206,41 @@ class ConsumerBase(RelationManagerBase):
         charm: CharmBase,
         relation_name: str = DEFAULT_RELATION_NAME,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
-        allow_free_standing_rules: bool = False,
+        recursive: bool = False,
     ):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
-        self.allow_free_standing_rules = allow_free_standing_rules
-        self._alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
         self.topology = JujuTopology.from_charm(charm)
 
+        try:
+            alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
+        except InvalidAlertRulePathError as e:
+            logger.warning(
+                "Invalid Loki alert rules folder at %s: %s",
+                e.alert_rules_absolute_path,
+                e.message,
+            )
+        self._alert_rules_path = alert_rules_path
+
+        self._recursive = recursive
+
     def _handle_alert_rules(self, relation):
-        if self._charm.unit.is_leader():
-            alert_groups, invalid_files = load_alert_rules_from_dir(
-                self._alert_rules_path,
-                self.topology,
-                recursive=False,
-                allow_free_standing=self.allow_free_standing_rules,
-            )
-            alert_rules_error_message = self._check_alert_rules(alert_groups, invalid_files)
+        if not self._charm.unit.is_leader():
+            return
 
-            if alert_rules_error_message:
-                self.on.loki_push_api_alert_rules_error.emit(alert_rules_error_message)
+        alert_rules = AlertRules(self.topology)
+        alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
+        alert_rules_as_dict = alert_rules.as_dict()
 
-            relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
-            relation.data[self._charm.app]["alert_rules"] = json.dumps(
-                {"groups": alert_groups} if alert_groups else {}
-            )
+        # if alert_rules_error_message:
+        #     self.on.loki_push_api_alert_rules_error.emit(alert_rules_error_message)
 
-    def _check_alert_rules(self, alert_groups, invalid_files) -> str:
-        """Check alert rules.
-
-        Args:
-            alert_groups: a list of prometheus alert rule groups.
-            invalid_files: a list of invalid rules files.
-
-        Returns:
-            A string with the validation message. The message is not empty whether there are
-            invalid alert rules files or there are no alert rules groups.
-        """
-        message = ""
-
-        if invalid_files:
-            must_contain = ["'alert'", "'expr'"]
-            if not self.allow_free_standing_rules:
-                must_contain.append("'%%juju_topology%%'")
-
-            message = "Failed to read alert rules (must contain {}): ".format(
-                ", ".join(must_contain)
-            ) + ", ".join(map(str, invalid_files))
-        elif not alert_groups:
-            message = "No alert rules found in {}".format(self._alert_rules_path)
-
-        return message
+        relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
+        relation.data[self._charm.app]["alert_rules"] = json.dumps(
+            alert_rules_as_dict,
+            sort_keys=True,  # sort, to prevent unnecessary relation_changed events
+        )
 
 
 class LokiPushApiConsumer(ConsumerBase):
@@ -1135,7 +1254,7 @@ class LokiPushApiConsumer(ConsumerBase):
         charm: CharmBase,
         relation_name: str = DEFAULT_RELATION_NAME,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
-        allow_free_standing_rules: bool = False,
+        recursive: bool = True,
     ):
         """Construct a Loki charm client.
 
@@ -1155,10 +1274,7 @@ class LokiPushApiConsumer(ConsumerBase):
                 are found, this method will raise either an exception of type
                 NoRelationWithInterfaceFoundError or MultipleRelationsWithInterfaceFoundError,
                 respectively.
-            alert_rules_path: an optional path for the location of alert rules
-                files. Defaults to "./src/loki_alert_rules",
-                resolved from the directory hosting the charm entry file.
-                The alert rules are automatically updated on charm upgrade.
+            recursive: Whether or not to scan for rule files recursively.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1183,7 +1299,7 @@ class LokiPushApiConsumer(ConsumerBase):
         _validate_relation_by_interface_and_direction(
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires
         )
-        super().__init__(charm, relation_name, alert_rules_path, allow_free_standing_rules)
+        super().__init__(charm, relation_name, alert_rules_path, recursive)
         self._stored.set_default(loki_push_api={})
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_logging_relation_changed)

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -5,7 +5,7 @@ import json
 import os
 import textwrap
 import unittest
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import yaml
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer, _is_valid_rule
@@ -100,12 +100,10 @@ class TestLokiPushApiConsumer(unittest.TestCase):
             None,
         )
 
-    @patch(
-        "charms.loki_k8s.v0.loki_push_api.load_alert_rules_from_dir",
-        new_callable=PropertyMock,
-    )
-    def test__on_logging_relation_changed(self, mock_alert_rules):
-        mock_alert_rules.return_value = (LABELED_ALERT_RULES, [])
+    @patch("charms.loki_k8s.v0.loki_push_api.AlertRules.add_path")
+    @patch("charms.loki_k8s.v0.loki_push_api.AlertRules.as_dict", new=lambda *a, **kw: {})
+    def test__on_logging_relation_changed(self, mock_as_dict):
+        mock_as_dict.return_value = (LABELED_ALERT_RULES, {})
         loki_push_api = "http://10.1.2.3:3100/loki/api/v1/push"
         self.harness.set_leader(True)
         rel_id = self.harness.add_relation("logging", "promtail")
@@ -194,7 +192,7 @@ class TestReloadAlertRules(unittest.TestCase):
                 super().__init__(*args)
                 self._port = 3100
                 self.loki_consumer = LokiPushApiConsumer(
-                    self, alert_rules_path=alert_rules_path, allow_free_standing_rules=True
+                    self, alert_rules_path=alert_rules_path, recursive=True
                 )
 
         self.harness = Harness(ConsumerCharm, meta=ConsumerCharm.metadata_yaml)


### PR DESCRIPTION
This PR brings in the AlertRules class from prom to loki.
This allows loki to read alerts in both formats - official and short-form.

The diff looks big because the branch is based on #76. When #76 merges, the diff will become smaller.

This change is (urgently) needed by https://github.com/canonical/cos-configuration-k8s-operator/pull/6