### PR TITLE
Replace '/' with '_' in topology.identifier

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -673,7 +673,7 @@ class JujuTopology:
     def identifier(self) -> str:
         """Format the topology information into a terse string."""
         # This is odd, but may have `None` as a model key
-        return "_".join([str(val) for val in self.as_dict().values()])
+        return "_".join([str(val) for val in self.as_dict().values()]).replace("/", "_")
 
     @property
     def promql_labels(self) -> str:


### PR DESCRIPTION
Since Loki and Prom both use `container.push()` for rules, which
blindly converts any string with '/' in it to a directory tree,
we may accidentally write nested paths when we don't intend to.

Replace path separators.