### PR TITLE
FIX #91 - Loki push_api lib should validate alert rules

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -131,8 +131,8 @@ The `LokiPushApiProvider` object has several responsibilities:
 
 Once these alert rules are sent over relation data, the `LokiPushApiProvider` object
 stores these files in the directory `/loki/rules` inside the Loki charm container. After
-storing alert rules files, the object will check alert rules by querying
-Loki API endpoint: [`loki/api/v1/rules`](https://grafana.com/docs/loki/latest/api/#list-rule-groups).
+storing alert rules files, the object will check alert rules by querying Loki API
+endpoint: [`loki/api/v1/rules`](https://grafana.com/docs/loki/latest/api/#list-rule-groups).
 If there are errors with alert rules a `loki_push_api_alert_rules_error` event will
 be emitted, in the other hand if there are no error a `loki_push_api_alert_rules_ok`
 event will be emitted.

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -444,8 +444,8 @@ from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional
+from urllib import request
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 from zipfile import ZipFile
 
 import yaml
@@ -1276,12 +1276,11 @@ class LokiPushApiProvider(RelationManagerBase):
                 error because it failed to list rule group.
         """
         url = "http://127.0.0.1:{}/loki/api/v1/rules".format(self.port)
-        req = Request(url)
+        req = request.Request(url)
         try:
-            urlopen(req)
+            request.urlopen(req)
         except HTTPError as e:
-            msg = e.read().decode("utf-8")
-
+            msg = e.msg  # type: ignore
             if e.code == 404 and "no rule groups found" in msg:
                 logger.debug("Checking alert rules: No rule groups found")
                 self.on.loki_push_api_alert_rules_ok.emit()
@@ -1933,7 +1932,7 @@ class LogProxyConsumer(ConsumerBase):
             )
         url = relations[0].data[relations[0].app].get("promtail_binary_zip_url")
 
-        with urlopen(url) as r:
+        with request.urlopen(url) as r:
             file_bytes = r.read()
             with open(BINARY_ZIP_PATH, "wb") as f:
                 f.write(file_bytes)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1336,11 +1336,11 @@ class LokiPushApiProvider(RelationManagerBase):
         Args:
             container: Container which has alert rules files to be deleted
         """
-        container.remove_path(self._rules_dir, recursive=True)
+        files = container.list_files(self._rules_dir)
         logger.debug("Previous Alert rules files deleted")
-        # Since container.remove_path deletes the directory itself with its files
-        # we should create it again.
-        os.makedirs(self._rules_dir, exist_ok=True)
+        for f in files:
+            logger.debug("Removing file... %s", f.path)
+            container.remove_path(f.path)
 
     def _generate_alert_rules_files(self, container: Container) -> None:
         """Generate and upload alert rules files.

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -152,7 +152,7 @@ This events should be observed in the charm that uses `LokiPushApiProvider`:
     def _loki_push_api_alert_rules_changed(self, event):
         if event.error:
             self.unit.status = BlockedStatus(event.message)
-            return
+            return False
 
         ...
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -153,7 +153,7 @@ These events should be observed in the charm that uses `LokiPushApiProvider`:
         )
 
     def _loki_push_api_alert_rules_error(self, event):
-        self.unit.status = BlockedStatus("Errors in alert rule groups. See debug-log.")
+        self.unit.status = BlockedStatus("Errors in alert rule groups. Check juju debug-log.")
 
     def _loki_push_api_alert_rules_ok(self, event):
         self.unit.status = ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -168,7 +168,6 @@ class LokiOperatorCharm(CharmBase):
         """Gets LokiPushApiProvider instance into `self.loki_provider`."""
         try:
             version = self._loki_server.version
-            # self.loki_provider = self.loki_provider or LokiPushApiProvider(self)
             logger.debug("Loki Provider is available. Loki version: %s", version)
         except LokiServerNotReadyError as e:
             self.unit.status = WaitingStatus(str(e))

--- a/src/charm.py
+++ b/src/charm.py
@@ -90,7 +90,7 @@ class LokiOperatorCharm(CharmBase):
         self._configure(event)
 
     def _loki_push_api_alert_rules_error(self, event):
-        self.unit.status = BlockedStatus("Errors in alert rule groups. See debug-log.")
+        self.unit.status = BlockedStatus("Errors in alert rule groups. Check juju debug-log.")
 
     def _loki_push_api_alert_rules_ok(self, event):
         self.unit.status = ActiveStatus()

--- a/tests/integration/test_alert_rules.py
+++ b/tests/integration/test_alert_rules.py
@@ -18,6 +18,7 @@ app_name = METADATA["name"]
 resources = {"loki-image": METADATA["resources"]["loki-image"]["upstream-source"]}
 rules_app = "cos-config"
 rules_app2 = "cos-config2"
+rules_app3 = "cos-config3"
 
 
 @pytest.mark.abort_on_fail
@@ -115,3 +116,31 @@ async def test_remove_app_one_alert_rules_is_reteined(ops_test):
 
     rules_after_delete_relation2 = await loki_rules(ops_test, app_name)
     assert len(rules_after_delete_relation2) == 1
+
+
+@pytest.mark.abort_on_fail
+async def test_wrong_alert_rule(ops_test):
+    await asyncio.gather(
+        ops_test.model.deploy(
+            "ch:cos-configuration-k8s",
+            application_name=rules_app3,
+            channel="edge",
+            config={
+                "git_repo": "https://github.com/canonical/loki-k8s-operator",
+                "git_branch": "error_alerts",
+                "loki_alert_rules_path": "tests/sample_rule_files/free-standing/error",
+            },
+        ),
+    )
+
+    # force an update, just in case the files showed up on disk after the last hook fired
+    action = await ops_test.model.applications[rules_app3].units[0].run_action("sync-now")
+    await action.wait()
+
+    # form a relation between loki and the app that provides rules
+    await ops_test.model.add_relation(app_name, rules_app3)
+
+    async with IPAddressWorkaround(ops_test):
+        await ops_test.model.wait_for_idle(
+            apps=[app_name], status="blocked", timeout=1000
+        )

--- a/tests/integration/test_alert_rules.py
+++ b/tests/integration/test_alert_rules.py
@@ -120,17 +120,15 @@ async def test_remove_app_one_alert_rules_is_reteined(ops_test):
 
 @pytest.mark.abort_on_fail
 async def test_wrong_alert_rule(ops_test):
-    await asyncio.gather(
-        ops_test.model.deploy(
-            "ch:cos-configuration-k8s",
-            application_name=rules_app3,
-            channel="edge",
-            config={
-                "git_repo": "https://github.com/canonical/loki-k8s-operator",
-                "git_branch": "error_alerts",
-                "loki_alert_rules_path": "tests/sample_rule_files/free-standing/error",
-            },
-        ),
+    await ops_test.model.deploy(
+        "ch:cos-configuration-k8s",
+        application_name=rules_app3,
+        channel="edge",
+        config={
+            "git_repo": "https://github.com/canonical/loki-k8s-operator",
+            "git_branch": "error_alerts",
+            "loki_alert_rules_path": "tests/sample_rule_files/free-standing/error",
+        },
     )
 
     # force an update, just in case the files showed up on disk after the last hook fired

--- a/tests/integration/test_alert_rules.py
+++ b/tests/integration/test_alert_rules.py
@@ -141,6 +141,4 @@ async def test_wrong_alert_rule(ops_test):
     await ops_test.model.add_relation(app_name, rules_app3)
 
     async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name], status="blocked", timeout=1000
-        )
+        await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -76,6 +76,7 @@ class FakeLokiCharm(CharmBase):
                 "make_dir": lambda *a, **kw: None,
                 "remove_path": lambda *a, **kw: None,
                 "can_connect": lambda *a, **kw: True,
+                "list_files": lambda *a, **kw: [],
             },
         )
         with patch("ops.testing._TestingPebbleClient.make_dir"):


### PR DESCRIPTION
This PR introduces changes to `LokiPushApiProvider`

- Once a relation is established and alert rules are sent through relation data, the object will check alert rules by querying Loki API. If there are no errors a `loki_push_api_alert_rules_ok` event is emitted. In the other hand if there are errors with alert rules, `loki_push_api_alert_rules_error` event is emitted.
- Loki charm now observes these new events and sets unit status accordingly.
- Refactor in `_remove_alert_rules_files()`. Now we delete one by one alert rule files instead of removing the entire directory.