### PR TITLE
Handle empty endpoints list

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -2008,9 +2008,7 @@ class LogProxyConsumer(ConsumerBase):
         """
         clients = []  # type: list
         for relation in self._charm.model.relations.get(self._relation_name, []):
-            endpoints = json.loads(relation.data[relation.app].get("endpoints", ""))
-            if endpoints:
-                clients += endpoints
+            clients = clients + json.loads(relation.data[relation.app].get("endpoints", "[]"))
         return clients
 
     def _server_config(self) -> dict:

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -167,6 +167,12 @@ class TestLogProxyConsumer(unittest.TestCase):
             {x["url"] for x in self.harness.charm._log_proxy._clients_list()}, expected_clients
         )
 
+    def test__empty_clients_list(self):
+        # Ensure we do not raise an exception if the clients list is empty
+        rel_id = self.harness.add_relation("log-proxy", "agent")
+        self.harness.add_relation_unit(rel_id, "agent/0")
+        self.assertEqual(self.harness.charm._log_proxy._clients_list(), [])
+
     def test__get_container_container_name_not_exist(self):
         # Container do not exist
         container_name = "loki_container"


### PR DESCRIPTION
I got a temporary error state from the loki_push_api relation when the remote unit had not yet published endpoints. That caused an exception to be raised. This PR fixes that.