### PR TITLE
Correctly treat empty rule files

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -907,7 +907,7 @@ class AlertRules:
         with file_path.open() as rf:
             # Load a list of rules from file then add labels and filters
             try:
-                rule_file = yaml.safe_load(rf)
+                rule_file = yaml.safe_load(rf) or {}
 
             except Exception as e:
                 logger.error("Failed to read alert rules from %s: %s", file_path.name, e)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -921,7 +921,8 @@ class AlertRules:
                 alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
             else:
                 # invalid/unsupported
-                logger.error("Invalid rules file: %s", file_path.name)
+                reason = "file is empty" if not rule_file else "unexpected file structure"
+                logger.error("Invalid rules file (%s): %s", reason, file_path.name)
                 return []
 
             # update rules with additional metadata

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -281,6 +281,8 @@ class TestAlertRuleFormat(unittest.TestCase):
     In those cases a warning should be emitted.
     """
 
+    NO_ALERTS = json.dumps({})  # relation data representation for the case of "no alerts"
+
     def setUp(self):
         self.sandbox = TempFS("consumer_rule_files", auto_clean=True)
         self.addCleanup(self.sandbox.close)
@@ -317,14 +319,21 @@ class TestAlertRuleFormat(unittest.TestCase):
 
     def test_empty_rule_files_are_dropped_and_produce_an_error(self):
         """Scenario: Consumer charm attempts to forward an empty rule file."""
+        # GIVEN a bunch of empty rule files (and ONLY empty rule files)
         self.sandbox.writetext("empty.rule", "")
         self.sandbox.writetext("whitespace1.rule", " ")
         self.sandbox.writetext("whitespace2.rule", "\n")
         self.sandbox.writetext("whitespace3.rule", "\r\n")
 
+        # WHEN charm starts
         with self.assertLogs(level="ERROR") as logger:
             self.harness.begin_with_initial_hooks()
 
+        # THEN relation data is empty (empty rule files do not get forwarded in any way)
+        relation = self.harness.charm.model.get_relation("logging")
+        self.assertEqual(relation.data[self.harness.charm.app].get("alert_rules"), self.NO_ALERTS)
+
+        # AND an error message is recorded for every empty file
         logger_output = "\n".join(logger.output)
         self.assertIn("empty.rule", logger_output)
         self.assertIn("whitespace1.rule", logger_output)
@@ -333,12 +342,19 @@ class TestAlertRuleFormat(unittest.TestCase):
 
     def test_rules_files_with_invalid_yaml_are_dropped_and_produce_an_error(self):
         """Scenario: Consumer charm attempts to forward a rule file which is invalid yaml."""
+        # GIVEN a bunch of invalid yaml rule files (and ONLY invalid yaml rule files)
         self.sandbox.writetext("tab.rule", "\t")
         self.sandbox.writetext("multicolon.rule", "this: is: not: yaml")
 
+        # WHEN charm starts
         with self.assertLogs(level="ERROR") as logger:
             self.harness.begin_with_initial_hooks()
 
+        # THEN relation data is empty (invalid rule files do not get forwarded in any way)
+        relation = self.harness.charm.model.get_relation("logging")
+        self.assertEqual(relation.data[self.harness.charm.app].get("alert_rules"), self.NO_ALERTS)
+
+        # AND an error message is recorded for every invalid file
         logger_output = "\n".join(logger.output)
         self.assertIn("tab.rule", logger_output)
         self.assertIn("multicolon.rule", logger_output)

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -317,4 +317,7 @@ class TestAlertRuleFormats(unittest.TestCase):
         """Scenario: Consumer charm attempts to forward an empty rule file."""
         # TODO write empty rule file
         self.sandbox.writetext("empty.rule", "")
-        self.harness.begin_with_initial_hooks()
+
+        with self.assertLogs(level="ERROR") as logger:
+            self.harness.begin_with_initial_hooks()
+            self.assertIn("empty.rule", "\n".join(logger.output))

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,7 @@ deps =
     pytest
     coverage[toml]
     responses
+    fs
     -r{toxinidir}/requirements.txt
 commands =
     coverage run \


### PR DESCRIPTION
`yaml.safe_load` may return a None. This PR makes sure this case is correctly handled.

Resolves #98.

Crossref: OPENG-649