### PR TITLE
Update alert rules to not use "juju_unit" as part of the topology

### DIFF
--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -383,9 +383,6 @@ class TestAlertRuleFormat(unittest.TestCase):
         self.harness.begin_with_initial_hooks()
         relation = self.harness.charm.model.get_relation("logging")
         rules = json.loads(relation.data[self.harness.charm.app].get("alert_rules"))
-        import pprint
-
-        pprint.pprint(rules)
         expr = rules["groups"][0]["rules"][0]["expr"]
         self.assertTrue(
             "juju_model" in expr
@@ -423,9 +420,6 @@ class TestAlertRuleFormat(unittest.TestCase):
         self.harness.begin_with_initial_hooks()
         relation = self.harness.charm.model.get_relation("logging")
         rules = json.loads(relation.data[self.harness.charm.app].get("alert_rules"))
-        import pprint
-
-        pprint.pprint(rules)
         expr = rules["groups"][0]["rules"][0]["expr"]
         self.assertTrue(
             "juju_model" in expr

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -384,13 +384,11 @@ class TestAlertRuleFormat(unittest.TestCase):
         relation = self.harness.charm.model.get_relation("logging")
         rules = json.loads(relation.data[self.harness.charm.app].get("alert_rules"))
         expr = rules["groups"][0]["rules"][0]["expr"]
-        self.assertTrue(
-            "juju_model" in expr
-            and "juju_model_uuid" in expr
-            and "juju_application" in expr
-            and "juju_charm" in expr
-            and "juju_unit" not in expr
-        )
+        self.assertIn("juju_model", expr)
+        self.assertIn("juju_model_uuid", expr)
+        self.assertIn("juju_application", expr)
+        self.assertIn("juju_charm", expr)
+        self.assertNotIn("juju_unit", expr)
         self.assertEqual(
             set(rules["groups"][0]["rules"][0]["labels"]),
             {"juju_application", "juju_charm", "juju_model", "juju_model_uuid", "severity"},
@@ -421,13 +419,11 @@ class TestAlertRuleFormat(unittest.TestCase):
         relation = self.harness.charm.model.get_relation("logging")
         rules = json.loads(relation.data[self.harness.charm.app].get("alert_rules"))
         expr = rules["groups"][0]["rules"][0]["expr"]
-        self.assertTrue(
-            "juju_model" in expr
-            and "juju_model_uuid" in expr
-            and "juju_application" in expr
-            and "juju_charm" in expr
-            and "juju_unit" in expr
-        )
+        self.assertIn("juju_model", expr)
+        self.assertIn("juju_model_uuid", expr)
+        self.assertIn("juju_application", expr)
+        self.assertIn("juju_charm", expr)
+        self.assertIn("juju_unit", expr)
         self.assertEqual(
             set(rules["groups"][0]["rules"][0]["labels"]),
             {


### PR DESCRIPTION
This makes it so that all units will trigger alerts instead of just the leader.

## Issue
When using the loki_push_api library, "juju_unit" is added to the alert rules. This causes the rule to only apply to the leader and not to the other unit.

## Solution
I used the updated JujuTopology class copied from prometheus_scrape with a minor modification to make it work in loki_push_api. This removes the "juju_unit" key from the alert rules.

## Context
Similar to [this PR](https://github.com/canonical/prometheus-k8s-operator/pull/239)

## Testing Instructions
Deploy a charm that has loki alert rules defined. (cassandra-k8s from the "update_for_cos" branch has this)
Relate to loki-k8s
Use `juju show-unit` and `curl http://address/loki/api/v1/rules` to verify the labels and expression are both correct.


## Release Notes
* Update alert rules to not use "juju_unit" as part of the topology. This makes it so that all units will trigger alerts instead of just the leader.

## Additional
In lieu of an integration test which Balbir is currently writing, here is the output of `show-unit` while using the updated lib
```
loki/0:
  opened-ports: []
  charm: local:focal/loki-k8s-2
  leader: true
  relation-info:
  - endpoint: logging
    related-endpoint: log-proxy
    application-data:
      alert_rules: '{"groups": [{"name": "lma_f6eed17b-0b64-41b4-87b5-c56390663aa9_cass_cassandra-k8s_alert_on_error_alerts",
        "rules": [{"alert": "alert_on_error", "annotations": {"summary": "Logs found
        at ERROR level"}, "expr": "rate({juju_model=\"lma\", juju_model_uuid=\"f6eed17b-0b64-41b4-87b5-c56390663aa9\",
        juju_application=\"cass\", juju_charm=\"cassandra-k8s\"}|=\"ERROR\"[5m]) >
        0", "for": "1m", "labels": {"juju_application": "cass", "juju_charm": "cassandra-k8s",
        "juju_model": "lma", "juju_model_uuid": "f6eed17b-0b64-41b4-87b5-c56390663aa9",
        "severity": "critical"}}]}]}'
      metadata: '{"model": "lma", "model_uuid": "f6eed17b-0b64-41b4-87b5-c56390663aa9",
        "application": "cass", "unit": "cass/0", "charm_name": "cassandra-k8s"}'
    related-units:
      cass/0:
        in-scope: true
        data:
          egress-subnets: 10.152.183.122/32
          ingress-address: 10.152.183.122
          private-address: 10.152.183.122
  - endpoint: logging
    related-endpoint: logging
    application-data:
      alert_rules: '{"groups": [{"name": "lma_f6eed17b-0b64-41b4-87b5-c56390663aa9_spring_spring-music_alert_on_error_alerts",
        "rules": [{"alert": "alert_on_error", "annotations": {"summary": "Logs found
        at ERROR level"}, "expr": "rate({juju_model=\"lma\", juju_model_uuid=\"f6eed17b-0b64-41b4-87b5-c56390663aa9\",
        juju_application=\"spring\", juju_charm=\"spring-music\"}|=\"ERROR\"[5m])
        > 0", "for": "1m", "labels": {"juju_application": "spring", "juju_charm":
        "spring-music", "juju_model": "lma", "juju_model_uuid": "f6eed17b-0b64-41b4-87b5-c56390663aa9",
        "severity": "critical"}}]}]}'
      metadata: '{"model": "lma", "model_uuid": "f6eed17b-0b64-41b4-87b5-c56390663aa9",
        "application": "spring", "unit": "spring/0", "charm_name": "spring-music"}'
    related-units:
      spring/0:
        in-scope: true
        data:
          egress-subnets: 10.152.183.222/32
          ingress-address: 10.152.183.222
          private-address: 10.152.183.222
  provider-id: loki-0
  address: 10.1.121.164
```