### PR TITLE
Automatically release statically-compiled promtail binaries

### DIFF
--- a/.github/workflows/build-promtail-release.yaml
+++ b/.github/workflows/build-promtail-release.yaml
@@ -1,0 +1,174 @@
+name: Build Promtail releases
+on:
+  # Manual trigger
+  workflow_call:
+    inputs:
+      release:
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+
+  build:
+    name: Build statically-linked Promtail
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64] # [amd64, arm64] # GitHub workflows do not support YAML anchors :-(
+    steps:
+      - name: Checkout grafana/loki, tag ${{inputs.release}}
+        uses: actions/checkout@v2
+        with:
+          repository: grafana/loki
+          ref: ${{inputs.release}}
+          fetch-depth: 1
+          path: ./loki-upstream
+      - name: Checkout ${{github.repository}}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: ./loki-k8s-operator
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.8
+      - name: Build Promtail
+        # We run the make-based build with CGO_ENABLED=0
+        # because we want statically-linked binaries and
+        # cross-build for the specified architecture
+        run: |
+          cd ./loki-upstream
+
+          CGO_ENABLED=0 GOHOSTOS=linux GOARCH=${{matrix.arch}} make clients/cmd/promtail/promtail
+
+          mkdir -p ./dist/loki_linux_${{matrix.arch}}
+          mv clients/cmd/promtail/promtail ./dist/loki_linux_${{matrix.arch}}/
+      - name: Attach promtail-${{matrix.arch}} artifact to run
+        uses: actions/upload-artifact@v3
+        with:
+          name: promtail-${{matrix.arch}}
+          path: ./loki-upstream/dist/loki_linux_${{matrix.arch}}/promtail
+
+  test:
+    name: Test Promtail
+    runs-on: ubuntu-latest
+    needs: build
+    # TODO: Also run tests on arm64
+    strategy:
+      matrix:
+        arch: [amd64] # [amd64, arm64]
+        base: [alpine, debian, rh-ubi8, scratch, ubuntu]
+    steps:
+      - name: Checkout ${{github.repository}}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Download the promtail-${{matrix.arch}} artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: promtail-${{matrix.arch}}
+          path: ./dist/loki_linux_${{matrix.arch}}/
+      - name: Check the linkage of the Promtail binary
+        run: |
+          file ./dist/loki_linux_${{matrix.arch}}/promtail
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and test ${{matrix.base}} image
+        # If promtail is borked on this base, the `docker run` invocation will fail
+        run: |
+          DOCKER_BUILDKIT=1 docker build . -f promtail-build/static/test/Dockerfile.${{matrix.base}} -t promtail-${{matrix.base}}
+          docker run promtail-${{matrix.base}}
+
+  tag:
+    name: Publish Promtail release to ${{github.repository}}
+    runs-on: ubuntu-latest
+    needs: test
+    env:
+      RELEASE: promtail-${{inputs.release}}
+    steps:
+      - name: Checkout grafana/loki, tag ${{inputs.release}}
+        uses: actions/checkout@v2
+        with:
+          repository: grafana/loki
+          ref: ${{inputs.release}}
+          fetch-depth: 1
+          path: ./loki-upstream
+      - name: Checkout ${{github.repository}}, ${{github.ref}}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: ./loki-k8s-operator
+      - name: Create shallow tag
+        # We rebase the commit from the release tag from the upstream loki
+        # repository on the initial commit of canonical/loki-k8s-operator,
+        # because GitHub does not allow us to push a shallow tag (tag to a
+        # commit with no parent), so we "reconcile" the history of the
+        # two repositories to have the initial commit of canonical/loki-k8s-operator
+        # as common history.
+        #
+        # We also remove the build automation from the tag, as that is not something
+        # we use, and if we left the .github folder, the pushing of the tag
+        # to canonical/loki-k8s-operator would fail with:
+        #
+        #  refusing to allow a GitHub App to create or update workflow \
+        #    `.github/workflows/backport.yml` without `workflows` permission
+        run: |
+          initial_operator_commit=$(cd ./loki-k8s-operator && git log main --oneline | tail -1 | awk '{ print $1 }')
+          cd ./loki-upstream
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git remote add charm ../loki-k8s-operator
+          git fetch charm
+          git rebase "${initial_operator_commit}" --strategy-option ours
+
+          echo "Removing build automation from the commit"
+
+          git rm -rf .github || true
+          git rm -rf .circleci || true
+          git rm -rf .drone || true
+          git rm .golangci.yml || true
+
+          echo "Creating the new commit"
+
+          git commit --amend --no-edit
+
+          echo "Creating the new tag"
+
+          git tag "${RELEASE}"
+
+          echo "Pushing the tag to the local ${{github.repository}} clone"
+
+          git push charm "${RELEASE}"
+
+          echo "Pushing the tag to the upstream ${{github.repository}} repository"
+
+          cd ../loki-k8s-operator
+          git push origin "${RELEASE}"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: tag
+    steps:
+      - name: Download the artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: List artifacts
+        run: |
+          find .
+      - name: Prepare artifacts for release
+        run: |
+          mkdir release
+          for f in artifacts/promtail-*; do cp "${f}/promtail" "release/$(basename ${f})"; done
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          name: "Promtail ${{inputs.release}}"
+          body: |
+            Statically-linked builds for Promtail, based on the [upstream '${{inputs.release}}'](https://github.com/grafana/loki/releases/tag/${{inputs.release}}) release of the `grafana/loki` project.
+          artifacts: release/*
+          tag: promtail-${{inputs.release}}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-promtail-releases.yaml
+++ b/.github/workflows/check-promtail-releases.yaml
@@ -1,0 +1,43 @@
+name: Check for new Promtail releases
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Check regularly the upstream every four hours
+  schedule:
+    - cron:  '0 0,4,8,12,16,20 * * *'
+
+jobs:
+  check:
+    name: Detect new releases
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{steps.check.outputs.release}}
+    steps:
+      # Find out what is the latest release of grafana/loki
+      - id: loki-latest-release
+        uses: pozetroninc/github-action-get-latest-release@v0.5.0
+        with:
+          repository: grafana/loki
+          excludes: prerelease, draft
+      # Check out the tags of our repo to compare
+      - name: Checkout canonical/loki-k8s-operator
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - id: check
+        name: Check for new releases
+        run: |
+          release=$(git show-ref --tags promtail-${{steps.loki-latest-release.outputs.release}} --quiet }} && echo -n '' || echo '${{ steps.loki-latest-release.outputs.release }}' )
+          if [ -n "${release}" ]; then
+            echo "::set-output name=release::${release}"
+            echo "New upstream release ${{steps.loki-latest-release.outputs.release}} found"
+          else
+            echo "No new upstream release found"
+          fi
+
+  trigger-build:
+    uses: ./.github/workflows/build-promtail-release.yaml
+    needs: check
+    if: ${{ needs.check.outputs.release != '' }}
+    with:
+      release: ${{needs.check.outputs.release}}

--- a/PROMTAIL_RELEASES.md
+++ b/PROMTAIL_RELEASES.md
@@ -1,0 +1,23 @@
+# Static releases of Promtail binaries
+
+In order to support any container running Linux with the [LogProxyConsumer](lib/charms/loki_k8s/v0/loki_push_api.py), we need builds of `promtail` that are statically linked.
+
+## Why statically linking Promtail?
+
+Static linking is necessary due to the various versions of libc (glibc, muslc), or even the absence of any libc implementation, to be found in containers based on container images other than `ubuntu` and the like.
+For example, Alpine-based containers ship muslc.
+Distroless-based and "from scratch" containers often have no libc at all.
+And the `promtail` builds from [upstream](https://github.com/grafana/loki/releases/) effectively work only on a subset of containers, which is a limitation we cannot afford.
+
+## How we build statically-linked Promtail binaries
+
+The build-and-release process for statically-linked `promtail` binaries is as follows:
+
+1. Every 4 hours, the cron-like [`check-promtail-releases`](.github/workflows/check-promtail-releases.yaml) GitHub workflow compares the latest upstream release of Loki with specific `promtail-*` tags in this repository.
+For example, the upstream `v2.4.2` tag pointed at by the upstream release, means that the `check-promtail-releases` workflow checks for a `promtail-v2.4.2` tag in this repository.
+2. If an upstream release is found that has no matching `promtail-*` tag, the [`build-promtail-release.yaml`](.github/workflows/build-promtail-release.yaml) is triggered, which:
+  1. Statically compile `promtail` for different architectures
+  2. Try the binary by building [containers with different base images](promtail-build/static/test) and run then with a `docker run` command
+  3. Create a shallow tag of the original Loki codebase (without history) and create the `promtail-*` tag from it.
+  4. Create a GitHub release with the promtail binaries, pointing at the `promtail-*` tag
+  

--- a/promtail-build/static/test/Dockerfile.alpine
+++ b/promtail-build/static/test/Dockerfile.alpine
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+ADD --chmod=0755 ./dist/loki_linux_amd64/promtail /app/promtail
+
+ENTRYPOINT ["/app/promtail", "--version"]

--- a/promtail-build/static/test/Dockerfile.debian
+++ b/promtail-build/static/test/Dockerfile.debian
@@ -1,0 +1,5 @@
+FROM debian
+
+ADD --chmod=0755 ./dist/loki_linux_amd64/promtail /app/promtail
+
+ENTRYPOINT ["/app/promtail", "--version"]

--- a/promtail-build/static/test/Dockerfile.rh-ubi8
+++ b/promtail-build/static/test/Dockerfile.rh-ubi8
@@ -1,0 +1,5 @@
+FROM redhat/ubi8
+
+ADD --chmod=0755 ./dist/loki_linux_amd64/promtail /app/promtail
+
+ENTRYPOINT ["/app/promtail", "--version"]

--- a/promtail-build/static/test/Dockerfile.scratch
+++ b/promtail-build/static/test/Dockerfile.scratch
@@ -1,0 +1,5 @@
+FROM scratch
+
+ADD --chmod=0755 ./dist/loki_linux_amd64/promtail /app/promtail
+
+ENTRYPOINT ["/app/promtail", "--version"]

--- a/promtail-build/static/test/Dockerfile.ubuntu
+++ b/promtail-build/static/test/Dockerfile.ubuntu
@@ -1,0 +1,5 @@
+FROM ubuntu
+
+ADD --chmod=0755 ./dist/loki_linux_amd64/promtail /app/promtail
+
+ENTRYPOINT ["/app/promtail", "--version"]

--- a/promtail-build/static/test/README.md
+++ b/promtail-build/static/test/README.md
@@ -1,0 +1,26 @@
+# Test Dockerfile for Promtail static
+
+This folder includes a battery of `Dockerfile`s to validate static builds of promtail.
+The images are very simple: they take a base, add promtail to it, and set the entrypoint to running `promtail --version`.
+If promtail is dynamically compiled and incompatible with the base image (e.g., wrong libc), running the container image will fail with:
+
+```sh
+michele@boombox:/tmp/loki$ docker run promtail-alpine-dynamic
+standard_init_linux.go:228: exec user process caused: no such file or directory
+```
+
+If promtail can run on top of the provided base, the output will look like the following:
+
+```sh
+michele@boombox:/tmp/loki$ docker run promtail-alpine
+promtail, version  (branch: , revision: )
+  build user:       
+  build date:       
+  go version:       go1.17.8
+  platform:         linux/amd64
+```
+
+## How to add more test base images
+
+1. Add a `Dockerfile.<base>` in this folder
+2. Add `<base>` to the matrix of the `test` job in the [Build promtail](.github/workflows/build-promtail-release.yaml) GitHub workflow


### PR DESCRIPTION
## Issue

Automatically build, validate and ship statically-compiled `promtail` binaries based on [upstream `grafana/loki` releases](https://github.com/grafana/loki/releases).

## Solution

1. Every 4 hours, the cron-like [`check-promtail-releases`](.github/workflows/check-promtail-releases.yaml) GitHub workflow compares the latest upstream release of Loki with specific `promtail-*` tags in this repository.
For example, the upstream `v2.4.2` tag pointed at by the upstream release, means that the `check-promtail-releases` workflow checks for a `promtail-v2.4.2` tag in this repository.
2. If an upstream release is found that has no matching `promtail-*` tag, the [`build-promtail-release.yaml`](.github/workflows/build-promtail-release.yaml) is triggered, which:
   1. Statically compile `promtail` for different architectures
   2. Try the binary by building [containers with different base images](promtail-build/static/test) and run then with a `docker run` command
   3. Create a shallow tag of the original Loki codebase (without history) and create the `promtail-*` tag from it.
   4. Create a GitHub release with the promtail binaries, pointing at the `promtail-*` tag

Given the fact that we do not yet have `arm64`-based GitHub runners at our disposal, the build process currently builds only for `amd64`.
However, all it should take to build `arm64`, when we have runners for it, is add `arm64` to the `matrix.arch` fields in the GitHub workflows.

## Context

Static linking is necessary due to the various versions of libc (glibc, muslc), or even the absence of any libc implementation, to be found in containers based on container images other than `ubuntu` and the like.
For example, Alpine-based containers ship muslc.
Distroless-based and "from scratch" containers often have no libc at all.
And the `promtail` builds from [upstream](https://github.com/grafana/loki/releases/) effectively work only on a subset of containers, which is a limitation we cannot afford.

## Testing Instructions

Run the build manually from https://github.com/canonical/loki-k8s-operator/actions, wait for the GitHub release to appear in https://github.com/canonical/loki-k8s-operator/releases, grab a `promtail` binary, and try it out :D

## Release Notes

This repository is going to regularly release statically-compiled `promtail` binaries tailing the upstream releases from [upstream `grafana/loki`](https://github.com/grafana/loki/releases/).