### PR TITLE
Compress promtail binaries for release with gzip

### DIFF
--- a/.github/workflows/build-promtail-release.yaml
+++ b/.github/workflows/build-promtail-release.yaml
@@ -221,7 +221,9 @@ jobs:
       - name: Prepare artifacts for release
         run: |
           mkdir release
-          for f in artifacts/promtail-*; do cp "${f}/promtail" "release/$(basename ${f})"; done
+          for f in artifacts/promtail-*; do cp "${f}/promtail" "release/$(basename ${f})";  done
+          cd release
+          for f in *; do gzip ${f}; done
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Issue

Reduce download size of Promtail binaries for the LogProxyConsumer charms.

## Solution

Compress the binaries with gz upon the publication of the GitHub release.

## Context

It is a tragedy that we cannot have GitHub compress the content for us based on MIME types and Accept headers.

## Testing Instructions

Check https://github.com/mmanciop/loki-operator/releases/tag/promtail-v2.4.2
