### PR TITLE
Fix default value for json.loads

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -2008,7 +2008,7 @@ class LogProxyConsumer(ConsumerBase):
         """
         clients = []  # type: list
         for relation in self._charm.model.relations.get(self._relation_name, []):
-            endpoints = json.loads(relation.data[relation.app].get("endpoints", "[]"))
+            endpoints = json.loads(relation.data[relation.app].get("endpoints", ""))
             if endpoints:
                 clients += endpoints
         return clients

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1221,13 +1221,7 @@ class LokiPushApiProvider(RelationManagerBase):
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_logging_relation_changed)
         self.framework.observe(events.relation_changed, self._on_logging_relation_changed)
-        self.framework.observe(events.relation_created, self._on_logging_relation_created)
         self.framework.observe(events.relation_departed, self._on_logging_relation_departed)
-
-    def _on_logging_relation_created(self, event: RelationCreatedEvent):
-        if self._charm.unit.is_leader():
-            event.relation.data[self._charm.app].update(self._promtail_binary_url)
-            logger.debug("Saved promtail binary url: %s", self._promtail_binary_url)
 
     def _on_logging_relation_changed(self, event: HookEvent):
         """Handle changes in related consumers.
@@ -1246,13 +1240,6 @@ class LokiPushApiProvider(RelationManagerBase):
             for relation in self._charm.model.relations[self._relation_name]:
                 self._process_logging_relation_changed(relation)
 
-    def regenerate_rule_files(self):
-        """Regenerate rule files within container from relation data."""
-        logger.debug("Saved alerts rules to disk")
-        self._remove_alert_rules_files(self.container)
-        self._generate_alert_rules_files(self.container)
-        self._check_alert_rules()
-
     def _process_logging_relation_changed(self, relation: Relation):
         """Handle changes in related consumers.
 
@@ -1266,11 +1253,17 @@ class LokiPushApiProvider(RelationManagerBase):
             relation: the `Relation` instance to update.
         """
         if self._charm.unit.is_leader():
+            relation.data[self._charm.app].update(self._promtail_binary_url)
+            logger.debug("Saved promtail binary url: %s", self._promtail_binary_url)
             relation.data[self._charm.app]["endpoints"] = json.dumps(self._endpoints())
             logger.debug("Saved endpoints in relation data")
 
         if relation.data.get(relation.app).get("alert_rules"):
-            self.regenerate_rule_files()
+            """Regenerate rule files within container from relation data."""
+            logger.debug("Saved alerts rules to disk")
+            self._remove_alert_rules_files(self.container)
+            self._generate_alert_rules_files(self.container)
+            self._check_alert_rules()
 
     def _endpoints(self) -> List[dict]:
         """Return a list of Loki Push Api endpoints."""
@@ -1344,34 +1337,7 @@ class LokiPushApiProvider(RelationManagerBase):
             event: a `CharmEvent` in response to which the Loki
                 charm must update its relation data.
         """
-        if self.model.unit == event.departing_unit:
-            # This unit is the departing unit, so any changes it makes to relation data won't get
-            # propagated anyway, so nothing to do in this case.
-            return
-        elif self.model.unit.app == event.departing_unit.app:
-            # A peer unit is leaving. Need to update list of endpoints.
-            # This is buggy because if the leader unit is the departed unit and no other unit was
-            # elected as leader yet then the following would be skipped and the same logic should
-            # probably go into leader-elected as well.
-            if not self._charm.unit.is_leader():
-                return
-
-            for relation in self._charm.model.relations[self._relation_name]:
-                # TODO: make sure _endpoints does not include the departing unit
-                relation.data[self._charm.app]["endpoints"] = json.dumps(self._endpoints())
-            logger.debug("Saved endpoints in relation data")
-        else:
-            # A regular relation's unit is departing. Need to regenerate rule files.
-            # However, in relation-departed, the departing relation data may still be visible,
-            # so this is not the right place for it.
-            # However, can't regenerate rules in relation-broken, because relation-broken is seen
-            # only by the departed unit.
-            # HOWEVER non-leader units for some reason get "ERROR permission denied" when trying to
-            # relation-get, so need a leader guard anyway.
-            if not self._charm.unit.is_leader():
-                return
-
-            self.regenerate_rule_files()
+        self._process_logging_relation_changed(event.relation)
 
     @property
     def _promtail_binary_url(self) -> dict:
@@ -1643,13 +1609,7 @@ class LokiPushApiConsumer(ConsumerBase):
         """
         endpoints = []  # type: list
         for relation in self._charm.model.relations[self._relation_name]:
-            with contextlib.suppress(ModelError):
-                # Suppressing ModelError, which may be raised if this method is called during
-                # departure, which would results in:
-                # ops.model.ModelError: b'ERROR permission denied\n'
-                endpoints = endpoints + json.loads(
-                    relation.data[relation.app].get("endpoints", "[]")
-                )
+            endpoints = endpoints + json.loads(relation.data[relation.app].get("endpoints", "[]"))
         return endpoints
 
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -2008,7 +2008,7 @@ class LogProxyConsumer(ConsumerBase):
         """
         clients = []  # type: list
         for relation in self._charm.model.relations.get(self._relation_name, []):
-            endpoints = json.loads(relation.data[relation.app].get("endpoints", ""))
+            endpoints = json.loads(relation.data[relation.app].get("endpoints", "[]"))
             if endpoints:
                 clients += endpoints
         return clients

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -434,7 +434,6 @@ Loki Push API and alert rules.
 Units of consumer charm send their alert rules over app relation data using the `alert_rules`
 key.
 """
-import contextlib
 import json
 import logging
 import os

--- a/tests/integration/test_rerelate.py
+++ b/tests/integration/test_rerelate.py
@@ -52,11 +52,14 @@ async def test_build_and_deploy(ops_test: OpsTest, loki_charm, loki_tester_charm
             loki_charm, resources=resources, application_name=app_name, num_units=2
         ),
         ops_test.model.deploy(
-            loki_tester_charm, application_name="loki-tester",
+            loki_tester_charm,
+            application_name="loki-tester",
         ),
         ops_test.model.deploy(
-            "ch:alertmanager-k8s", application_name="alertmanager", channel="edge",
-        )
+            "ch:alertmanager-k8s",
+            application_name="alertmanager",
+            channel="edge",
+        ),
     )
 
     await asyncio.gather(
@@ -90,8 +93,21 @@ async def test_rerelate(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_remove_related_app(ops_test: OpsTest):
+
+    cmd = [
+        "juju",
+        "remove-application",
+        "--destroy-storage",
+        "--force",
+        "--no-wait",
+        "loki-tester",
+    ]
+
+    # retcode, stdout, stderr = await ops_test.run(*cmd)
+
     await asyncio.gather(
-        ops_test.model.applications["loki-tester"].remove(),
+        # ops_test.model.applications["loki-tester"].remove(),  # this hangs, for some reason
+        ops_test.run(*cmd),
         ops_test.model.applications["alertmanager"].remove(),
         # Block until it is really gone. Added after an itest failed when tried to redeploy:
         # juju.errors.JujuError: ['cannot add application "...": application already exists']
@@ -107,11 +123,14 @@ async def test_remove_related_app(ops_test: OpsTest):
 async def test_rerelate_app(ops_test: OpsTest, loki_tester_charm):
     await asyncio.gather(
         ops_test.model.deploy(
-            loki_tester_charm, application_name="loki-tester",
+            loki_tester_charm,
+            application_name="loki-tester",
         ),
         ops_test.model.deploy(
-            "ch:alertmanager-k8s", application_name="alertmanager", channel="edge",
-        )
+            "ch:alertmanager-k8s",
+            application_name="alertmanager",
+            channel="edge",
+        ),
     )
 
     await asyncio.gather(

--- a/tests/integration/test_rerelate.py
+++ b/tests/integration/test_rerelate.py
@@ -103,11 +103,11 @@ async def test_remove_related_app(ops_test: OpsTest):
         "loki-tester",
     ]
 
-    # retcode, stdout, stderr = await ops_test.run(*cmd)
+    # TODO figure out why loki tester is not going away nicely
     await ops_test.model.applications["loki-tester"].remove(),  # this hangs, for some reason
+    await ops_test.run(*cmd),  # so now force remove, which helps it go away
 
     await asyncio.gather(
-        ops_test.run(*cmd),  # and now force remove
         ops_test.model.applications["alertmanager"].remove(),
         # Block until it is really gone. Added after an itest failed when tried to redeploy:
         # juju.errors.JujuError: ['cannot add application "...": application already exists']

--- a/tests/integration/test_rerelate.py
+++ b/tests/integration/test_rerelate.py
@@ -104,10 +104,10 @@ async def test_remove_related_app(ops_test: OpsTest):
     ]
 
     # retcode, stdout, stderr = await ops_test.run(*cmd)
+    await ops_test.model.applications["loki-tester"].remove(),  # this hangs, for some reason
 
     await asyncio.gather(
-        # ops_test.model.applications["loki-tester"].remove(),  # this hangs, for some reason
-        ops_test.run(*cmd),
+        ops_test.run(*cmd),  # and now force remove
         ops_test.model.applications["alertmanager"].remove(),
         # Block until it is really gone. Added after an itest failed when tried to redeploy:
         # juju.errors.JujuError: ['cannot add application "...": application already exists']


### PR DESCRIPTION
## Issue
#132 itest is [currently failing](https://github.com/canonical/loki-k8s-operator/runs/5843517601?check_suite_focus=true#step:4:527) for a JSONDecodeError becaus a fix in #114 didn't quite fix the problem.

## Solution
Instead of 
https://github.com/canonical/loki-k8s-operator/blob/c7e25d66ad8d5f158378910e3e54f33a71f1462b/lib/charms/loki_k8s/v0/loki_push_api.py#L2009
it should be `get("endpoints", "[]"))`, similar to elsewhere in the same file:
https://github.com/canonical/loki-k8s-operator/blob/c7e25d66ad8d5f158378910e3e54f33a71f1462b/lib/charms/loki_k8s/v0/loki_push_api.py#L1611

## Context
#114 was merged with a red itest after confirming the tests pass locally. Seems like they passed due to timing coincidence that avoided `raise_on_error`.


## Testing Instructions
`tox -e integration -- -k test_rerelate`

## Release Notes
Fix default value for json.loads in loki_push_api.
