### PR TITLE
Create provider only when ready

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1233,6 +1233,9 @@ class LokiPushApiProvider(RelationManagerBase):
             event: a `CharmEvent` in response to which the consumer
                 charm must update its relation data.
         """
+        if not self.container.can_connect():
+            return
+
         if isinstance(event, RelationEvent):
             self._process_logging_relation_changed(event.relation)
         else:

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1239,6 +1239,9 @@ class LokiPushApiProvider(RelationManagerBase):
                 charm must update its relation data.
         """
         if not self.container.can_connect():
+            # We do not defer the event because, if it is a relation created/changed, we will
+            # process the relation again on pebble_ready, and the nature of the event is not
+            # taken into account in the following logic.
             return
 
         if isinstance(event, RelationEvent):

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1223,6 +1223,11 @@ class LokiPushApiProvider(RelationManagerBase):
         self.framework.observe(events.relation_changed, self._on_logging_relation_changed)
         self.framework.observe(events.relation_departed, self._on_logging_relation_departed)
 
+        for container_name in self._charm.unit.containers:
+            self.framework.observe(
+                self._charm.on[container_name].pebble_ready, self._on_logging_relation_changed
+            )
+
     def _on_logging_relation_changed(self, event: HookEvent):
         """Handle changes in related consumers.
 

--- a/tests/integration/test_rerelate.py
+++ b/tests/integration/test_rerelate.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import ModelConfigChange, is_loki_up
+from helpers import is_loki_up
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -40,32 +40,33 @@ class RelatedApp:
         )
 
 
-related_apps = [
-    RelatedApp("alertmanager", "ch:alertmanager-k8s", "alertmanager", {}),
-    RelatedApp("cassandra", "ch:cassandra-k8s", "logging", {"heap_size": "1g"}),
-]
-
-
 async def test_setup_env(ops_test: OpsTest):
     await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, loki_charm):
+async def test_build_and_deploy(ops_test: OpsTest, loki_charm, loki_tester_charm):
     """Build the charm-under-test and deploy it together with related charms."""
     await asyncio.gather(
         ops_test.model.deploy(
             loki_charm, resources=resources, application_name=app_name, num_units=2
         ),
-        *[app.deploy(ops_test) for app in related_apps],
+        ops_test.model.deploy(
+            loki_tester_charm,
+            application_name="loki-tester",
+        ),
+        ops_test.model.deploy(
+            "ch:alertmanager-k8s",
+            application_name="alertmanager",
+            channel="edge",
+        ),
     )
 
     await asyncio.gather(
-        *[ops_test.model.add_relation(app_name, app.name) for app in related_apps],
+        ops_test.model.add_relation(app_name, "loki-tester"),
+        ops_test.model.add_relation(app_name, "alertmanager"),
     )
-
-    async with ModelConfigChange(ops_test, {"update-status-hook-interval": "60s"}):
-        await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(status="active", timeout=1000)
 
     assert await is_loki_up(ops_test, app_name)
 
@@ -73,10 +74,8 @@ async def test_build_and_deploy(ops_test: OpsTest, loki_charm):
 @pytest.mark.abort_on_fail
 async def test_remove_relation(ops_test: OpsTest):
     await asyncio.gather(
-        *[
-            ops_test.model.applications[app_name].remove_relation(app.relname, app.name)
-            for app in related_apps
-        ],
+        ops_test.model.applications[app_name].remove_relation("logging", "loki-tester"),
+        ops_test.model.applications[app_name].remove_relation("alertmanager", "alertmanager"),
     )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     assert await is_loki_up(ops_test, app_name)
@@ -85,7 +84,8 @@ async def test_remove_relation(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_rerelate(ops_test: OpsTest):
     await asyncio.gather(
-        *[ops_test.model.add_relation(app_name, app.name) for app in related_apps],
+        ops_test.model.add_relation(app_name, "loki-tester"),
+        ops_test.model.add_relation(app_name, "alertmanager"),
     )
     await ops_test.model.wait_for_idle(status="active", timeout=1000)
     assert await is_loki_up(ops_test, app_name)
@@ -93,14 +93,26 @@ async def test_rerelate(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_remove_related_app(ops_test: OpsTest):
+
+    cmd = [
+        "juju",
+        "remove-application",
+        "--destroy-storage",
+        "--force",
+        "--no-wait",
+        "loki-tester",
+    ]
+
+    # retcode, stdout, stderr = await ops_test.run(*cmd)
+
     await asyncio.gather(
-        *[ops_test.model.applications[app.name].remove() for app in related_apps],
+        # ops_test.model.applications["loki-tester"].remove(),  # this hangs, for some reason
+        ops_test.run(*cmd),
+        ops_test.model.applications["alertmanager"].remove(),
         # Block until it is really gone. Added after an itest failed when tried to redeploy:
         # juju.errors.JujuError: ['cannot add application "...": application already exists']
-        *[
-            ops_test.model.block_until(lambda: app.name not in ops_test.model.applications)
-            for app in related_apps
-        ],
+        ops_test.model.block_until(lambda: "loki-tester" not in ops_test.model.applications),
+        ops_test.model.block_until(lambda: "alertmanager" not in ops_test.model.applications),
     )
 
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
@@ -108,14 +120,23 @@ async def test_remove_related_app(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_rerelate_app(ops_test: OpsTest):
+async def test_rerelate_app(ops_test: OpsTest, loki_tester_charm):
     await asyncio.gather(
-        *[app.deploy(ops_test) for app in related_apps],
-    )
-    await asyncio.gather(
-        *[ops_test.model.add_relation(app_name, app.name) for app in related_apps],
+        ops_test.model.deploy(
+            loki_tester_charm,
+            application_name="loki-tester",
+        ),
+        ops_test.model.deploy(
+            "ch:alertmanager-k8s",
+            application_name="alertmanager",
+            channel="edge",
+        ),
     )
 
-    async with ModelConfigChange(ops_test, {"update-status-hook-interval": "60s"}):
-        await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    await asyncio.gather(
+        ops_test.model.add_relation(app_name, "loki-tester"),
+        ops_test.model.add_relation(app_name, "alertmanager"),
+    )
+    await ops_test.model.wait_for_idle(status="active", timeout=1000)
+
     assert await is_loki_up(ops_test, app_name)

--- a/tests/sample_rule_files/free-standing/alerting.rule
+++ b/tests/sample_rule_files/free-standing/alerting.rule
@@ -12,12 +12,3 @@ groups:
             severity: page
         annotations:
             summary: High request latency
-  - name: credentials_leak
-    rules:
-      - alert: http-credentials-leaked
-        annotations:
-          message: "{{ $labels.job }} is leaking http basic auth credentials."
-        expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
-        for: 10m
-        labels:
-          severity: critical

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -128,7 +128,7 @@ class TestCharm(unittest.TestCase):
 
     def test__provide_loki(self):
         with self.assertLogs(level="DEBUG") as logger:
-            self.harness.charm._provide_loki()
+            self.harness.charm._loki_is_active()
             self.assertEqual(
                 sorted(logger.output),
                 ["DEBUG:charm:Loki Provider is available. Loki version: 3.14159"],
@@ -136,17 +136,17 @@ class TestCharm(unittest.TestCase):
 
     def test__provide_loki_not_ready(self):
         self.mock_version.side_effect = LokiServerNotReadyError
-        self.harness.charm._provide_loki()
+        self.harness.charm._loki_is_active()
         self.assertIsInstance(self.harness.charm.unit.status, WaitingStatus)
 
     def test__provide_loki_server_error(self):
         self.mock_version.side_effect = LokiServerError
-        self.harness.charm._provide_loki()
+        self.harness.charm._loki_is_active()
         self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
     def test__loki_config(self):
         with self.assertLogs(level="DEBUG") as logger:
-            self.harness.charm._provide_loki()
+            self.harness.charm._loki_is_active()
             self.assertEqual(
                 sorted(logger.output),
                 ["DEBUG:charm:Loki Provider is available. Loki version: 3.14159"],

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -118,6 +118,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.LokiOperatorCharm._loki_config")
     def test__on_config_can_connect(self, mock_loki_config):
         mock_loki_config.return_value = yaml.safe_load(LOKI_CONFIG)
+        self.harness.set_can_connect(self.container_name, True)
         self.harness.set_leader(True)
 
         # Since harness was not started with begin_with_initial_hooks(), this must


### PR DESCRIPTION
## Issue

This PR addresses issue #112 and some of the additional concerns raised in that ticket.

At present the `LokiPushApiProvider` object is always instantiated in the Loki charm's constructor. However instantiating this provider object when the Loki server is unable to service HTTP requests may lead to errors, at least two of which can be anticipated
1. If `LokiPushApiProvider` gets a `RelationJoinedEvent` it will provide the consumer with its Push API endpoint URL. However this endpoint may not be operational and hence lead to errors in the consumer charm.
2. If the consumer charm forwards alert rules to `LokiPushApiProvider`, the provider charm will store these alert rules into Loki's alert rule folder and reload the rules. The provider charm will then try to check if the alert rules are valid by connecting to the `LokiPushApiProvider` HTTP API endpoint. Failure to make this connection will result in a false negative for the validity of these alert rules.

## Solution
In view of the above observations it is proposed that

- The _provide_loki() method be renamed to something like _is_loki_active(). Instead of raising exceptions this method may return a boolean that asserts if the Loki server HTTP API is responsive or not.
- Instantiation of the LokiPushApiProvider be guarded by check for _is_loki_active().

## Context
Issue #112 provides a details on context.

## Testing Instructions
This PR is work in progress and testing has not yet been considered

## Release Notes
LokiPushApiProvider now guarantees that when its sets a endpoint URL for the consumer, this endpoint will be reachable and active.