### PR TITLE
Stop spamming warning logs, prune and streamline code

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 on:
-  pull_request: 
+  pull_request:
     branches:
       - main
 
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@1.0.1-rc
         with:
@@ -36,7 +36,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run static analysis for /lib for 3.5
         run: tox -vve static-lib
-  
+
   static-charm:
     name: Static analysis of the charm and tests
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: latest/stable
+          juju-channel: 2.9/edge
           provider: microk8s
       - name: Run integration tests
         run: tox -vve integration

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 2.9/edge
+          juju-channel: 2.9/candidate
           provider: microk8s
       - name: Run integration tests
         run: tox -vve integration

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1329,14 +1329,14 @@ class LokiPushApiProvider(RelationManagerBase):
             )
             return False
         except URLError as e:
-            logger.error("URLERROR: Checking alert rules: %s", e.reason)
+            logger.error("Checking alert rules: %s", e.reason)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
             return False
         except Exception as e:
-            logger.error("EXCEPTION: Checking alert rules: %s", e)
+            logger.error("Checking alert rules: %s", e)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
@@ -1357,13 +1357,11 @@ class LokiPushApiProvider(RelationManagerBase):
     def unit_ip(self) -> str:
         """Returns unit's IP."""
         bind_address = ""
-        logger.warning("Trying to get IP")
         if self._charm.model.relations[self._relation_name]:
             relation = self._charm.model.relations[self._relation_name][0]
             bind_address = relation.data[self._charm.unit].get("public_address", "")
 
         if bind_address:
-            logger.warning("Returning IP %s", str(bind_address))
             return str(bind_address)
         logger.warning("No address found")
         return ""
@@ -1392,7 +1390,7 @@ class LokiPushApiProvider(RelationManagerBase):
         if not container.can_connect():
             return
 
-        logger.warning("Generating alert rules files")
+        logger.debug("Generating alert rules files")
         for identifier, alert_rules in self.alerts().items():
             filename = "{}_alert.rules".format(identifier)
             path = os.path.join(self._rules_dir, filename)
@@ -1434,22 +1432,17 @@ class LokiPushApiProvider(RelationManagerBase):
         """
         alerts = {}  # type: Dict[str, dict] # mapping b/w juju identifiers and alert rule files
         for relation in self._charm.model.relations[self._relation_name]:
-            logger.warning("Checking relation %s", relation)
             if not relation.units:
-                logger.warning("No units!")
                 continue
 
             alert_rules = json.loads(relation.data[relation.app].get("alert_rules", "{}"))
             if not alert_rules:
-                logger.warning("No rules!")
                 continue
 
             try:
                 # NOTE: this `metadata` key SHOULD NOT be changed to `scrape_metadata`
                 # to align with Prometheus without careful consideration'
-                logger.warning("Checking metadata")
                 metadata = json.loads(relation.data[relation.app]["metadata"])
-                logger.warning("Got metadata %s", metadata)
                 identifier = ProviderTopology.from_relation_data(metadata).identifier
                 alerts[identifier] = alert_rules
             except KeyError as e:
@@ -1509,7 +1502,7 @@ class ConsumerBase(RelationManagerBase):
         if not self._charm.unit.is_leader():
             return
 
-        logger.warning("Handling alert rules")
+        logger.debug("Handling alert rules")
         alert_rules = AlertRules(self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
@@ -1517,7 +1510,7 @@ class ConsumerBase(RelationManagerBase):
         # if alert_rules_error_message:
         #     self.on.loki_push_api_alert_rules_error.emit(alert_rules_error_message)
 
-        logger.warning("Setting alert rules")
+        logger.debug("Setting alert rules")
         relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
         relation.data[self._charm.app]["alert_rules"] = json.dumps(
             alert_rules_as_dict,
@@ -1602,7 +1595,6 @@ class LokiPushApiConsumer(ConsumerBase):
             loki_push_api_alert_rules_error: This event is emitted when an invalid alert rules
                 file is encountered or if `alert_rules_path` is empty.
         """
-        logger.warning("Changed! %s", event)
         if isinstance(event, RelationEvent):
             self._process_logging_relation_changed(event.relation)
         else:
@@ -1616,7 +1608,6 @@ class LokiPushApiConsumer(ConsumerBase):
             self._handle_alert_rules(relation)
 
     def _process_logging_relation_changed(self, relation: Relation):
-        logger.warning("Changed")
         self._handle_alert_rules(relation)
         self.on.loki_push_api_endpoint_joined.emit()
 
@@ -1638,11 +1629,9 @@ class LokiPushApiConsumer(ConsumerBase):
         Returns:
             A list with Loki Push API endpoints.
         """
-        logger.warning("Trying to fetch loki endpoints")
         endpoints = []  # type: list
         for relation in self._charm.model.relations[self._relation_name]:
             endpoints = endpoints + json.loads(relation.data[relation.app].get("endpoints", "[]"))
-        logger.warning("Returning endpoints: %s", endpoints)
         return endpoints
 
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1307,7 +1307,7 @@ class LokiPushApiProvider(Object):
         Args:
             container: Container into which alert rules files are going to be uploaded
         """
-        file_mappings = {}  # type: ignore
+        file_mappings = {}
 
         logger.debug("Generating alert rules files")
         for identifier, alert_rules in self.alerts.items():

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1307,7 +1307,7 @@ class LokiPushApiProvider(Object):
         Args:
             container: Container into which alert rules files are going to be uploaded
         """
-        alert_rules = {}
+        alert_rules = {}  # type: ignore
 
         logger.debug("Generating alert rules files")
         for identifier, alert_rules in self.alerts.items():
@@ -1362,7 +1362,6 @@ class LokiPushApiProvider(Object):
                 log_msg = "Checking alert rules: No rule groups found"
                 logger.debug(log_msg)
                 self.on.loki_push_api_alert_rules_changed.emit(message=log_msg)
-                return False
 
             message = "{} - {}".format(e.code, e.msg)  # type: ignore
             logger.error("Checking alert rules: %s", message)
@@ -1370,26 +1369,22 @@ class LokiPushApiProvider(Object):
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
-            return False
         except URLError as e:
             logger.error("Checking alert rules: %s", e.reason)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
-            return False
         except Exception as e:
             logger.error("Checking alert rules: %s", e)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
-            return False
         else:
             log_msg = "Checking alert rules: Ok"
             logger.debug(log_msg)
             self.on.loki_push_api_alert_rules_changed.emit(message=log_msg)
-            return True
 
     @property
     def alerts(self) -> dict:

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1385,6 +1385,7 @@ class LokiPushApiProvider(Object):
                 log_msg = "Checking alert rules: No rule groups found"
                 logger.debug(log_msg)
                 self.on.loki_push_api_alert_rules_changed.emit(message=log_msg)
+                return
 
             message = "{} - {}".format(e.code, e.msg)  # type: ignore
             logger.error("Checking alert rules: %s", message)
@@ -1392,22 +1393,26 @@ class LokiPushApiProvider(Object):
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
+            return
         except URLError as e:
             logger.error("Checking alert rules: %s", e.reason)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
+            return
         except Exception as e:
             logger.error("Checking alert rules: %s", e)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
+            return
         else:
             log_msg = "Checking alert rules: Ok"
             logger.debug(log_msg)
             self.on.loki_push_api_alert_rules_changed.emit(message=log_msg)
+            return
 
     @property
     def alerts(self) -> dict:

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1307,7 +1307,7 @@ class LokiPushApiProvider(Object):
         Args:
             container: Container into which alert rules files are going to be uploaded
         """
-        alert_rules = {}  # type: ignore
+        alert_rules_mapping = {}  # type: ignore
 
         logger.debug("Generating alert rules files")
         for identifier, alert_rules in self.alerts.items():
@@ -1323,9 +1323,9 @@ class LokiPushApiProvider(Object):
         logger.debug("Removing existing alert rules")
         self._remove_alert_rules_files(container)
 
-        for filename, rules in alert_rules.items():
+        for filename, content in alert_rules_mapping.items():
             path = os.path.join(self._rules_dir, filename)
-            container.push(path, rules, make_dirs=True)
+            container.push(path, content, make_dirs=True)
             logger.debug("Updated alert rules file %s", filename)
 
     def _remove_alert_rules_files(self, container: Container) -> None:

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1307,12 +1307,12 @@ class LokiPushApiProvider(Object):
         Args:
             container: Container into which alert rules files are going to be uploaded
         """
-        alert_rules_mapping = {}  # type: ignore
+        file_mappings = {}  # type: ignore
 
         logger.debug("Generating alert rules files")
         for identifier, alert_rules in self.alerts.items():
             rules = yaml.dump({"groups": alert_rules["groups"]})
-            alert_rules["{}_alert.rules".format(identifier)] = rules
+            file_mappings["{}_alert.rules".format(identifier)] = rules
 
         logger.debug("Successfully generated alert rule files")
 
@@ -1323,7 +1323,7 @@ class LokiPushApiProvider(Object):
         logger.debug("Removing existing alert rules")
         self._remove_alert_rules_files(container)
 
-        for filename, content in alert_rules_mapping.items():
+        for filename, content in file_mappings.items():
             path = os.path.join(self._rules_dir, filename)
             container.push(path, content, make_dirs=True)
             logger.debug("Updated alert rules file %s", filename)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1037,7 +1037,7 @@ class AlertRules:
         elif path.is_file():
             self.alert_groups.extend(self._from_file(path.parent, path))
         else:
-            logger.debug("path does not exist: %s", path)
+            logger.debug("The alerts file does not exist: %s", path)
 
     def as_dict(self) -> dict:
         """Return standard alert rules file in dict representation.
@@ -1198,7 +1198,6 @@ class LokiPushApiProvider(Object):
         # create tenant dir so that the /loki/api/v1/rules endpoint returns "no rule groups found"
         # instead of "unable to read rule dir /loki/rules/fake: no such file or directory"
         if self.container.can_connect():
-            logger.debug("Cannot connect to container to make alert rules path!")
             try:
                 self.container.make_dir(self._rules_dir, make_parents=True)
             except (FileNotFoundError, ProtocolError, PathError):
@@ -1491,7 +1490,6 @@ class ConsumerBase(Object):
         if not self._charm.unit.is_leader():
             return
 
-        logger.debug("Handling alert rules")
         alert_rules = AlertRules(self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
@@ -1499,7 +1497,6 @@ class ConsumerBase(Object):
         # if alert_rules_error_message:
         #     self.on.loki_push_api_alert_rules_error.emit(alert_rules_error_message)
 
-        logger.debug("Setting alert rules")
         relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
         relation.data[self._charm.app]["alert_rules"] = json.dumps(
             alert_rules_as_dict,
@@ -1752,7 +1749,6 @@ class LogProxyConsumer(ConsumerBase):
     def _on_relation_created(self, _: RelationCreatedEvent) -> None:
         """Event handler for `relation_created`."""
         if not self._container.can_connect():
-            logger.debug("Cannot connect to container to check promtail!")
             return
         if not self._is_promtail_installed():
             self._setup_promtail()
@@ -1766,7 +1762,6 @@ class LogProxyConsumer(ConsumerBase):
         self._handle_alert_rules(event.relation)
 
         if not self._container.can_connect():
-            logger.debug("Cannot connect to container to check promtail!")
             return
         if self.model.relations[self._relation_name] and not self._is_promtail_installed():
             self._setup_promtail()
@@ -1784,7 +1779,6 @@ class LogProxyConsumer(ConsumerBase):
             event: The event object `RelationDepartedEvent`.
         """
         if not self._container.can_connect():
-            logger.debug("Cannot connect to container to check promtail!")
             return
         if not self._charm.model.relations[self._relation_name]:
             self._container.stop(WORKLOAD_SERVICE_NAME)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -153,33 +153,6 @@ async def get_alertmanager_alerts(ops_test: OpsTest, unit_name, unit_num, retrie
     return alerts
 
 
-class IPAddressWorkaround:
-    """Context manager for deploying a charm that needs to have its IP address.
-
-    Due to a juju bug, occasionally some charms finish a startup sequence without
-    having an ip address returned by `bind_address`.
-    https://bugs.launchpad.net/juju/+bug/1929364
-
-    On entry, the context manager changes the update status interval to the minimum 10s, so that
-    the update_status hook is trigger shortly.
-    On exit, the context manager restores the interval to its previous value.
-    """
-
-    def __init__(self, ops_test: OpsTest):
-        self.ops_test = ops_test
-
-    async def __aenter__(self):
-        """On entry, the update status interval is set to the minimum 10s."""
-        config = await self.ops_test.model.get_config()
-        self.revert_to = config["update-status-hook-interval"]
-        await self.ops_test.model.set_config({"update-status-hook-interval": "10s"})
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, exc_traceback):
-        """On exit, the update status interval is reverted to its original value."""
-        await self.ops_test.model.set_config({"update-status-hook-interval": self.revert_to})
-
-
 class ModelConfigChange:
     """Context manager for temporarily changing a model config option."""
 

--- a/tests/integration/test_alert_rules_load.py
+++ b/tests/integration/test_alert_rules_load.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up, loki_rules
+from helpers import is_loki_up, loki_rules
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +29,8 @@ async def test_deploy(ops_test, loki_charm):
     """
     await ops_test.model.deploy(loki_charm, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)
 
@@ -51,10 +50,7 @@ async def test_first_relation_one_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app], status="active", timeout=1000)
 
     rules_after_relation = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation) == 1
@@ -72,10 +68,7 @@ async def test_second_relation_second_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app2)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app2], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app2], status="active", timeout=1000)
 
     rules_after_relation = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation) == 2
@@ -125,5 +118,4 @@ async def test_wrong_alert_rule(ops_test, faulty_loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app3)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up
+from helpers import is_loki_up
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +27,7 @@ async def test_build_and_deploy(ops_test):
     charm_under_test = await ops_test.build_charm(".")
     await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up
+from helpers import is_loki_up
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +22,9 @@ async def test_deploy_from_local_path(ops_test, loki_charm):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.deploy(loki_charm, application_name=app_name, resources=resources)
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        await is_loki_up(ops_test, app_name)
+    await ops_test.model.deploy(loki_charm, application_name=app_name, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await is_loki_up(ops_test, app_name)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_multiple_rule_providing_apps.py
+++ b/tests/integration/test_multiple_rule_providing_apps.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up, loki_rules
+from helpers import is_loki_up, loki_rules
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +30,8 @@ async def test_deploy(ops_test, loki_charm):
     """
     await ops_test.model.deploy(loki_charm, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)
 
@@ -52,10 +51,7 @@ async def test_first_relation_one_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app], status="active", timeout=1000)
     global rules_after_relation
     rules_after_relation = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation) == 1
@@ -73,10 +69,7 @@ async def test_second_relation_second_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app2)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app2], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app2], status="active", timeout=1000)
 
     rules_after_relation2 = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation2) == 2
@@ -125,6 +118,4 @@ async def test_wrong_alert_rule(ops_test, faulty_loki_tester_charm):
 
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app3)
-
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up
+from helpers import is_loki_up
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_attempt, wait_exponential
 
@@ -35,15 +35,14 @@ async def test_setup_env(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_upgrade_edge_with_local_in_isolation(ops_test: OpsTest, loki_charm):
     """Deploy from charmhub and then upgrade with the charm-under-test."""
-    async with IPAddressWorkaround(ops_test):
-        logger.debug("deploy charm from charmhub")
-        await ops_test.model.deploy(f"ch:{app_name}", application_name=app_name, channel="edge")
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    logger.debug("deploy charm from charmhub")
+    await ops_test.model.deploy(f"ch:{app_name}", application_name=app_name, channel="edge")
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
-        logger.debug("upgrade deployed charm with local charm %s", loki_charm)
-        await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert await is_loki_up(ops_test, app_name)
+    logger.debug("upgrade deployed charm with local charm %s", loki_charm)
+    await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_loki_up(ops_test, app_name)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -58,6 +58,7 @@ async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, loki_c
         ops_test.model.add_relation(app_name, "am"),
         ops_test.model.add_relation(app_name, "grafana"),
     )
+    await ops_test.model.wait_for_idle(status="active", timeout=1000)
 
     # Refresh from path
     await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -58,7 +58,9 @@ async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, loki_c
         ops_test.model.add_relation(app_name, "am"),
         ops_test.model.add_relation(app_name, "grafana"),
     )
-    await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, "am", "grafana"], status="active", timeout=1000
+    )
 
     # Refresh from path
     await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)

--- a/tests/integration/test_upgrade_charm_retains_alerts.py
+++ b/tests/integration/test_upgrade_charm_retains_alerts.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up, loki_rules
+from helpers import is_loki_up, loki_rules
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +26,8 @@ async def test_deploy_charms(ops_test, loki_charm, loki_tester_charm):
     """
     await ops_test.model.deploy(loki_charm, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)
 
@@ -42,10 +41,7 @@ async def test_deploy_charms(ops_test, loki_charm, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app], status="active", timeout=1000)
 
     # verify setup is complete and as expected
     rules = await loki_rules(ops_test, app_name)
@@ -58,8 +54,7 @@ async def test_rule_files_are_retained_after_pod_upgraded(ops_test, loki_charm):
     logger.debug("upgrade deployed charm with local charm %s", loki_charm)
     await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
     assert await is_loki_up(ops_test, app_name)
     rules_after_upgrade = await loki_rules(ops_test, app_name)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -87,6 +87,14 @@ class FakeLokiCharm(CharmBase):
         with patch("ops.testing._TestingPebbleClient.make_dir"):
             self.loki_provider = LokiPushApiProvider(self, "logging")
 
+        self.framework.observe(
+            self.loki_provider.on.loki_push_api_alert_rules_changed, self.alert_events
+        )
+        self._stored.set_default(events=[])
+
+    def alert_events(self, event):
+        self._stored.events.append({"message": event.message, "error": event.error})
+
     @property
     def _loki_push_api(self) -> str:
         loki_push_api = f"http://{self.unit_ip}:{self.charm._port}/loki/api/v1/push"
@@ -175,30 +183,35 @@ class TestLokiPushApiProvider(unittest.TestCase):
     @patch("urllib.request.urlopen")
     def test__check_alert_rules_ok(self, mock_urlopen):
         mock_urlopen.return_value = True
-        self.assertTrue(self.harness.charm.loki_provider._check_alert_rules())
+        self.harness.charm.loki_provider._check_alert_rules()
+        self.assertEqual(self.harness.charm._stored.events[-1]["error"], False)
 
     @patch("urllib.request.urlopen")
     def test__check_alert_rules_httperror_404_ok(self, mock_urlopen):
         with patch("http.client.HTTPResponse") as mock_http_response:
             mock_http_response.read.side_effect = HTTPError(URL, 404, "no rule groups found", {}, io.BytesIO())  # type: ignore
             mock_urlopen.return_value = mock_http_response
-            self.assertTrue(self.harness.charm.loki_provider._check_alert_rules())
+            self.harness.charm.loki_provider._check_alert_rules()
+            self.assertEqual(self.harness.charm._stored.events[-1]["error"], False)
 
     @patch("urllib.request.urlopen")
     def test__check_alert_rules_httperror_404_error(self, mock_urlopen):
         with patch("http.client.HTTPResponse") as mock_http_response:
             mock_urlopen.side_effect = HTTPError(URL, 404, "404 page not found", {}, io.BytesIO())  # type: ignore
             mock_http_response.read.return_value = mock_urlopen.side_effect
-            self.assertFalse(self.harness.charm.loki_provider._check_alert_rules())
+            self.harness.charm.loki_provider._check_alert_rules()
+            self.assertEqual(self.harness.charm._stored.events[-1]["error"], True)
 
     @patch("urllib.request.urlopen")
     def test__check_alert_rules_httperror_400(self, mock_urlopen):
         with patch("http.client.HTTPResponse") as mock_http_response:
             mock_urlopen.side_effect = HTTPError(URL, 400, "Bad Request", {}, io.BytesIO())  # type: ignore
             mock_http_response.read.return_value = mock_urlopen.side_effect
-            self.assertFalse(self.harness.charm.loki_provider._check_alert_rules())
+            self.harness.charm.loki_provider._check_alert_rules()
+            self.assertEqual(self.harness.charm._stored.events[-1]["error"], True)
 
     @patch("urllib.request.urlopen")
     def test__check_alert_rules_urlerror(self, mock_urlopen):
         mock_urlopen.side_effect = URLError("Unknown host")
-        self.assertFalse(self.harness.charm.loki_provider._check_alert_rules())
+        self.harness.charm.loki_provider._check_alert_rules()
+        self.assertEqual(self.harness.charm._stored.events[-1]["error"], True)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -116,11 +116,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
         self.assertEqual(expected_value, self.harness.charm.loki_provider._endpoints())
 
     @patch(
-        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._generate_alert_rules_files",
-        MagicMock(),
-    )
-    @patch(
-        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._remove_alert_rules_files",
+        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._regenerate_alert_rules_files",
         MagicMock(),
     )
     @patch("ops.testing._TestingModelBackend.network_get")
@@ -172,7 +168,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")
 
-        alerts = self.harness.charm.loki_provider.alerts()
+        alerts = self.harness.charm.loki_provider.alerts
         self.assertEqual(len(alerts), 1)
         self.assertDictEqual(list(alerts.values())[0]["groups"][0], ALERT_RULES["groups"][0])
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -123,10 +123,6 @@ class TestLokiPushApiProvider(unittest.TestCase):
         ]
         self.assertEqual(expected_value, self.harness.charm.loki_provider._endpoints())
 
-    @patch(
-        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._regenerate_alert_rules_files",
-        MagicMock(),
-    )
     @patch("ops.testing._TestingModelBackend.network_get")
     def test__on_logging_relation_changed(self, mock_unit_ip):
         with self.assertLogs(level="DEBUG") as logger:
@@ -142,12 +138,15 @@ class TestLokiPushApiProvider(unittest.TestCase):
             rel_id = self.harness.add_relation("logging", "promtail")
             self.harness.add_relation_unit(rel_id, "promtail/0")
 
-            self.harness.update_relation_data(rel_id, "promtail", {"alert_rules": "ww"})
+            self.harness.update_relation_data(
+                rel_id, "promtail", {"alert_rules": json.dumps(ALERT_RULES)}
+            )
+            print(logger.output)
             self.assertTrue(
                 any(
                     [
                         log_msg
-                        == "DEBUG:charms.loki_k8s.v0.loki_push_api:Saved alerts rules to disk"
+                        == "DEBUG:charms.loki_k8s.v0.loki_push_api:Saved alert rules to disk"
                         for log_msg in logger.output
                     ]
                 )
@@ -179,7 +178,9 @@ class TestLokiPushApiProvider(unittest.TestCase):
         rel_id = self.harness.add_relation("logging", "promtail")
         self.harness.add_relation_unit(rel_id, "promtail/0")
 
-        self.harness.update_relation_data(rel_id, "promtail", {"alert_rules": "ww"})
+        self.harness.update_relation_data(
+            rel_id, "promtail", {"alert_rules": json.dumps(ALERT_RULES)}
+        )
         self.assertEqual(self.harness.charm.loki_provider._regenerate_alert_rules.call_count, 1)
 
         self.harness.remove_relation(rel_id)


### PR DESCRIPTION
## Issue
`loki_push_api` littered the logs with warning messages on every invocation if no alert rules were present in a relation, even if they were no included in the charm at all.

Closes #128
Closes #53
Closes #106
Closes #142 

## Solution
Emit messages in `LogProxyConsumer` and `LokiPushApi*` if we
cannot connect to the container.

Stop using `logger.warning` for messages when the alert rules path
doesn't exist -- default constructor args should mean endless
warnings.

Prune more dead code in `RelationManagerBase`, the methods of which
are never called anywhere.

Condense the alert rule generation/removal/updates into a single
method which tries to generate the alert rules _prior_ to removing
everything.

## Testing Instructions
Even running the unit tests is sufficient before and after this change.

## Release Notes
Prune log messages from `loki_push_api`