### PR TITLE
Accurately flag statuses from checking alert rules

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 on:
-  pull_request: 
+  pull_request:
     branches:
       - main
 
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@1.0.1-rc
         with:
@@ -36,7 +36,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run static analysis for /lib for 3.5
         run: tox -vve static-lib
-  
+
   static-charm:
     name: Static analysis of the charm and tests
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: latest/stable
+          juju-channel: 2.9/edge
           provider: microk8s
       - name: Run integration tests
         run: tox -vve integration

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 2.9/edge
+          juju-channel: 2.9/candidate
           provider: microk8s
       - name: Run integration tests
         run: tox -vve integration

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1329,14 +1329,14 @@ class LokiPushApiProvider(RelationManagerBase):
             )
             return False
         except URLError as e:
-            logger.error("URLERROR: Checking alert rules: %s", e.reason)
+            logger.error("Checking alert rules: %s", e.reason)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
             return False
         except Exception as e:
-            logger.error("EXCEPTION: Checking alert rules: %s", e)
+            logger.error("Checking alert rules: %s", e)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
@@ -1357,13 +1357,11 @@ class LokiPushApiProvider(RelationManagerBase):
     def unit_ip(self) -> str:
         """Returns unit's IP."""
         bind_address = ""
-        logger.warning("Trying to get IP")
         if self._charm.model.relations[self._relation_name]:
             relation = self._charm.model.relations[self._relation_name][0]
             bind_address = relation.data[self._charm.unit].get("public_address", "")
 
         if bind_address:
-            logger.warning("Returning IP %s", str(bind_address))
             return str(bind_address)
         logger.warning("No address found")
         return ""
@@ -1392,7 +1390,7 @@ class LokiPushApiProvider(RelationManagerBase):
         if not container.can_connect():
             return
 
-        logger.warning("Generating alert rules files")
+        logger.debug("Generating alert rules files")
         for identifier, alert_rules in self.alerts().items():
             filename = "{}_alert.rules".format(identifier)
             path = os.path.join(self._rules_dir, filename)
@@ -1434,22 +1432,17 @@ class LokiPushApiProvider(RelationManagerBase):
         """
         alerts = {}  # type: Dict[str, dict] # mapping b/w juju identifiers and alert rule files
         for relation in self._charm.model.relations[self._relation_name]:
-            logger.warning("Checking relation %s", relation)
             if not relation.units:
-                logger.warning("No units!")
                 continue
 
             alert_rules = json.loads(relation.data[relation.app].get("alert_rules", "{}"))
             if not alert_rules:
-                logger.warning("No rules!")
                 continue
 
             try:
                 # NOTE: this `metadata` key SHOULD NOT be changed to `scrape_metadata`
                 # to align with Prometheus without careful consideration'
-                logger.warning("Checking metadata")
                 metadata = json.loads(relation.data[relation.app]["metadata"])
-                logger.warning("Got metadata %s", metadata)
                 identifier = ProviderTopology.from_relation_data(metadata).identifier
                 alerts[identifier] = alert_rules
             except KeyError as e:
@@ -1509,7 +1502,7 @@ class ConsumerBase(RelationManagerBase):
         if not self._charm.unit.is_leader():
             return
 
-        logger.warning("Handling alert rules")
+        logger.debug("Handling alert rules")
         alert_rules = AlertRules(self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
@@ -1517,7 +1510,7 @@ class ConsumerBase(RelationManagerBase):
         # if alert_rules_error_message:
         #     self.on.loki_push_api_alert_rules_error.emit(alert_rules_error_message)
 
-        logger.warning("Setting alert rules")
+        logger.debug("Setting alert rules")
         relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
         relation.data[self._charm.app]["alert_rules"] = json.dumps(
             alert_rules_as_dict,
@@ -1602,7 +1595,6 @@ class LokiPushApiConsumer(ConsumerBase):
             loki_push_api_alert_rules_error: This event is emitted when an invalid alert rules
                 file is encountered or if `alert_rules_path` is empty.
         """
-        logger.warning("Changed! %s", event)
         if isinstance(event, RelationEvent):
             self._process_logging_relation_changed(event.relation)
         else:
@@ -1616,7 +1608,6 @@ class LokiPushApiConsumer(ConsumerBase):
             self._handle_alert_rules(relation)
 
     def _process_logging_relation_changed(self, relation: Relation):
-        logger.warning("Changed")
         self._handle_alert_rules(relation)
         self.on.loki_push_api_endpoint_joined.emit()
 
@@ -1638,11 +1629,9 @@ class LokiPushApiConsumer(ConsumerBase):
         Returns:
             A list with Loki Push API endpoints.
         """
-        logger.warning("Trying to fetch loki endpoints")
         endpoints = []  # type: list
         for relation in self._charm.model.relations[self._relation_name]:
             endpoints = endpoints + json.loads(relation.data[relation.app].get("endpoints", "[]"))
-        logger.warning("Returning endpoints: %s", endpoints)
         return endpoints
 
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1332,14 +1332,14 @@ class LokiPushApiProvider(RelationManagerBase):
             logger.error("Checking alert rules: %s", e.reason)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
-                message="Errors in alert rule groups. Check juju debug-log.",
+                message="Error connecting to Loki. Check juju debug-log.",
             )
             return False
         except Exception as e:
             logger.error("Checking alert rules: %s", e)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
-                message="Errors in alert rule groups. Check juju debug-log.",
+                message="Error connecting to Loki. Check juju debug-log.",
             )
             return False
         else:

--- a/src/charm.py
+++ b/src/charm.py
@@ -134,6 +134,13 @@ class LokiOperatorCharm(CharmBase):
             self._container.restart(self._name)
             logger.info("Loki (re)started")
 
+        # Don't clear alert error states on reconfigure
+        if (
+            isinstance(self.unit.status, BlockedStatus)
+            and "Errors in alert rule" in self.unit.status.message
+        ):
+            return
+
         self.unit.status = ActiveStatus()
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -135,6 +135,7 @@ class LokiOperatorCharm(CharmBase):
             logger.info("Loki (re)started")
 
         # Don't clear alert error states on reconfigure
+        # but let errors connecting clear after a restart
         if (
             isinstance(self.unit.status, BlockedStatus)
             and "Errors in alert rule" in self.unit.status.message

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -153,33 +153,6 @@ async def get_alertmanager_alerts(ops_test: OpsTest, unit_name, unit_num, retrie
     return alerts
 
 
-class IPAddressWorkaround:
-    """Context manager for deploying a charm that needs to have its IP address.
-
-    Due to a juju bug, occasionally some charms finish a startup sequence without
-    having an ip address returned by `bind_address`.
-    https://bugs.launchpad.net/juju/+bug/1929364
-
-    On entry, the context manager changes the update status interval to the minimum 10s, so that
-    the update_status hook is trigger shortly.
-    On exit, the context manager restores the interval to its previous value.
-    """
-
-    def __init__(self, ops_test: OpsTest):
-        self.ops_test = ops_test
-
-    async def __aenter__(self):
-        """On entry, the update status interval is set to the minimum 10s."""
-        config = await self.ops_test.model.get_config()
-        self.revert_to = config["update-status-hook-interval"]
-        await self.ops_test.model.set_config({"update-status-hook-interval": "10s"})
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, exc_traceback):
-        """On exit, the update status interval is reverted to its original value."""
-        await self.ops_test.model.set_config({"update-status-hook-interval": self.revert_to})
-
-
 class ModelConfigChange:
     """Context manager for temporarily changing a model config option."""
 

--- a/tests/integration/test_alert_rules_load.py
+++ b/tests/integration/test_alert_rules_load.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up, loki_rules
+from helpers import is_loki_up, loki_rules
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +29,8 @@ async def test_deploy(ops_test, loki_charm):
     """
     await ops_test.model.deploy(loki_charm, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)
 
@@ -51,10 +50,7 @@ async def test_first_relation_one_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app], status="active", timeout=1000)
 
     rules_after_relation = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation) == 1
@@ -72,10 +68,7 @@ async def test_second_relation_second_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app2)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app2], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app2], status="active", timeout=1000)
 
     rules_after_relation = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation) == 2
@@ -125,5 +118,4 @@ async def test_wrong_alert_rule(ops_test, faulty_loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app3)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up
+from helpers import is_loki_up
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +27,7 @@ async def test_build_and_deploy(ops_test):
     charm_under_test = await ops_test.build_charm(".")
     await ops_test.model.deploy(charm_under_test, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up
+from helpers import is_loki_up
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +22,9 @@ async def test_deploy_from_local_path(ops_test, loki_charm):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.deploy(loki_charm, application_name=app_name, resources=resources)
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        await is_loki_up(ops_test, app_name)
+    await ops_test.model.deploy(loki_charm, application_name=app_name, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await is_loki_up(ops_test, app_name)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_multiple_rule_providing_apps.py
+++ b/tests/integration/test_multiple_rule_providing_apps.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up, loki_rules
+from helpers import is_loki_up, loki_rules
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +30,8 @@ async def test_deploy(ops_test, loki_charm):
     """
     await ops_test.model.deploy(loki_charm, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)
 
@@ -52,10 +51,7 @@ async def test_first_relation_one_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app], status="active", timeout=1000)
     global rules_after_relation
     rules_after_relation = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation) == 1
@@ -73,10 +69,7 @@ async def test_second_relation_second_alert_rule(ops_test, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app2)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app2], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app2], status="active", timeout=1000)
 
     rules_after_relation2 = await loki_rules(ops_test, app_name)
     assert len(rules_after_relation2) == 2
@@ -125,6 +118,4 @@ async def test_wrong_alert_rule(ops_test, faulty_loki_tester_charm):
 
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app3)
-
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up
+from helpers import is_loki_up
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_attempt, wait_exponential
 
@@ -35,15 +35,14 @@ async def test_setup_env(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_upgrade_edge_with_local_in_isolation(ops_test: OpsTest, loki_charm):
     """Deploy from charmhub and then upgrade with the charm-under-test."""
-    async with IPAddressWorkaround(ops_test):
-        logger.debug("deploy charm from charmhub")
-        await ops_test.model.deploy(f"ch:{app_name}", application_name=app_name, channel="edge")
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    logger.debug("deploy charm from charmhub")
+    await ops_test.model.deploy(f"ch:{app_name}", application_name=app_name, channel="edge")
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
-        logger.debug("upgrade deployed charm with local charm %s", loki_charm)
-        await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert await is_loki_up(ops_test, app_name)
+    logger.debug("upgrade deployed charm with local charm %s", loki_charm)
+    await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert await is_loki_up(ops_test, app_name)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -58,6 +58,9 @@ async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, loki_c
         ops_test.model.add_relation(app_name, "am"),
         ops_test.model.add_relation(app_name, "grafana"),
     )
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, "am", "grafana"], status="active", timeout=1000
+    )
 
     # Refresh from path
     await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)

--- a/tests/integration/test_upgrade_charm_retains_alerts.py
+++ b/tests/integration/test_upgrade_charm_retains_alerts.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import IPAddressWorkaround, is_loki_up, loki_rules
+from helpers import is_loki_up, loki_rules
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +26,8 @@ async def test_deploy_charms(ops_test, loki_charm, loki_tester_charm):
     """
     await ops_test.model.deploy(loki_charm, resources=resources, application_name=app_name)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
-        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     assert await is_loki_up(ops_test, app_name)
 
@@ -42,10 +41,7 @@ async def test_deploy_charms(ops_test, loki_charm, loki_tester_charm):
     # form a relation between loki and the app that provides rules
     await ops_test.model.add_relation(app_name, rules_app)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(
-            apps=[app_name, rules_app], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(apps=[app_name, rules_app], status="active", timeout=1000)
 
     # verify setup is complete and as expected
     rules = await loki_rules(ops_test, app_name)
@@ -58,8 +54,7 @@ async def test_rule_files_are_retained_after_pod_upgraded(ops_test, loki_charm):
     logger.debug("upgrade deployed charm with local charm %s", loki_charm)
     await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
 
-    async with IPAddressWorkaround(ops_test):
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
     assert await is_loki_up(ops_test, app_name)
     rules_after_upgrade = await loki_rules(ops_test, app_name)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -137,11 +137,20 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._loki_push_api_alert_rules_changed(
             LokiPushApiAlertRulesChanged(
-                None, error=True, message="I should be in blocked status!"
+                None, error=True, message="Errors in alert rule groups: fubar!"
             )
         )
         self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
-        self.assertEqual(self.harness.charm.unit.status.message, "I should be in blocked status!")
+        self.assertEqual(
+            self.harness.charm.unit.status.message, "Errors in alert rule groups: fubar!"
+        )
+
+        # Emit another config changed to make sure we stay blocked
+        self.harness.charm.on.config_changed.emit()
+        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+        self.assertEqual(
+            self.harness.charm.unit.status.message, "Errors in alert rule groups: fubar!"
+        )
 
         self.harness.charm._loki_push_api_alert_rules_changed(
             LokiPushApiAlertRulesChanged(None, error=False)


### PR DESCRIPTION
## Issue
Previously, a failure in `_check_alert_rules` followed by almost
any other event could cause the state to be reset back to
`ActiveStatus`, since typechecking the event would _probably_ not
be correct.

Closes #113

## Solution
Kill the "common exit hook" in `charm.py`, and move explicit state
checks for alerting events to the appropriate method

## Testing Instructions
Updated even more unit tests.

## Release Notes
Accurately flag statuses from checking alert rules