### PR TITLE
No common exit hook in lib

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 on:
-  pull_request: 
+  pull_request:
     branches:
       - main
 
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@1.0.1-rc
         with:
@@ -36,7 +36,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run static analysis for /lib for 3.5
         run: tox -vve static-lib
-  
+
   static-charm:
     name: Static analysis of the charm and tests
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: latest/stable
+          juju-channel: 2.9/edge
           provider: microk8s
       - name: Run integration tests
         run: tox -vve integration

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 2.9/edge
+          juju-channel: 2.9/candidate
           provider: microk8s
       - name: Run integration tests
         run: tox -vve integration

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1329,14 +1329,14 @@ class LokiPushApiProvider(RelationManagerBase):
             )
             return False
         except URLError as e:
-            logger.error("URLERROR: Checking alert rules: %s", e.reason)
+            logger.error("Checking alert rules: %s", e.reason)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
             )
             return False
         except Exception as e:
-            logger.error("EXCEPTION: Checking alert rules: %s", e)
+            logger.error("Checking alert rules: %s", e)
             self.on.loki_push_api_alert_rules_changed.emit(
                 error=True,
                 message="Errors in alert rule groups. Check juju debug-log.",
@@ -1357,13 +1357,11 @@ class LokiPushApiProvider(RelationManagerBase):
     def unit_ip(self) -> str:
         """Returns unit's IP."""
         bind_address = ""
-        logger.warning("Trying to get IP")
         if self._charm.model.relations[self._relation_name]:
             relation = self._charm.model.relations[self._relation_name][0]
             bind_address = relation.data[self._charm.unit].get("public_address", "")
 
         if bind_address:
-            logger.warning("Returning IP %s", str(bind_address))
             return str(bind_address)
         logger.warning("No address found")
         return ""
@@ -1392,7 +1390,7 @@ class LokiPushApiProvider(RelationManagerBase):
         if not container.can_connect():
             return
 
-        logger.warning("Generating alert rules files")
+        logger.debug("Generating alert rules files")
         for identifier, alert_rules in self.alerts().items():
             filename = "{}_alert.rules".format(identifier)
             path = os.path.join(self._rules_dir, filename)
@@ -1434,22 +1432,17 @@ class LokiPushApiProvider(RelationManagerBase):
         """
         alerts = {}  # type: Dict[str, dict] # mapping b/w juju identifiers and alert rule files
         for relation in self._charm.model.relations[self._relation_name]:
-            logger.warning("Checking relation %s", relation)
             if not relation.units:
-                logger.warning("No units!")
                 continue
 
             alert_rules = json.loads(relation.data[relation.app].get("alert_rules", "{}"))
             if not alert_rules:
-                logger.warning("No rules!")
                 continue
 
             try:
                 # NOTE: this `metadata` key SHOULD NOT be changed to `scrape_metadata`
                 # to align with Prometheus without careful consideration'
-                logger.warning("Checking metadata")
                 metadata = json.loads(relation.data[relation.app]["metadata"])
-                logger.warning("Got metadata %s", metadata)
                 identifier = ProviderTopology.from_relation_data(metadata).identifier
                 alerts[identifier] = alert_rules
             except KeyError as e:
@@ -1509,7 +1502,7 @@ class ConsumerBase(RelationManagerBase):
         if not self._charm.unit.is_leader():
             return
 
-        logger.warning("Handling alert rules")
+        logger.debug("Handling alert rules")
         alert_rules = AlertRules(self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
@@ -1517,7 +1510,7 @@ class ConsumerBase(RelationManagerBase):
         # if alert_rules_error_message:
         #     self.on.loki_push_api_alert_rules_error.emit(alert_rules_error_message)
 
-        logger.warning("Setting alert rules")
+        logger.debug("Setting alert rules")
         relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
         relation.data[self._charm.app]["alert_rules"] = json.dumps(
             alert_rules_as_dict,
@@ -1602,7 +1595,6 @@ class LokiPushApiConsumer(ConsumerBase):
             loki_push_api_alert_rules_error: This event is emitted when an invalid alert rules
                 file is encountered or if `alert_rules_path` is empty.
         """
-        logger.warning("Changed! %s", event)
         if isinstance(event, RelationEvent):
             self._process_logging_relation_changed(event.relation)
         else:
@@ -1616,7 +1608,6 @@ class LokiPushApiConsumer(ConsumerBase):
             self._handle_alert_rules(relation)
 
     def _process_logging_relation_changed(self, relation: Relation):
-        logger.warning("Changed")
         self._handle_alert_rules(relation)
         self.on.loki_push_api_endpoint_joined.emit()
 
@@ -1638,11 +1629,9 @@ class LokiPushApiConsumer(ConsumerBase):
         Returns:
             A list with Loki Push API endpoints.
         """
-        logger.warning("Trying to fetch loki endpoints")
         endpoints = []  # type: list
         for relation in self._charm.model.relations[self._relation_name]:
             endpoints = endpoints + json.loads(relation.data[relation.app].get("endpoints", "[]"))
-        logger.warning("Returning endpoints: %s", endpoints)
         return endpoints
 
 

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -177,7 +177,7 @@ class TestReloadAlertRules(unittest.TestCase):
 
         # The "GIVEN" statements explicitly work against the way unittest is designed, and it is
         # only through sheer luck that they have worked thus far
-        unittest.TestLoader.sortTestMethodsUsing = None
+        unittest.TestLoader.sortTestMethodsUsing = None  # type: ignore
         self.sandbox = TempFolderSandbox()
         alert_rules_path = os.path.join(self.sandbox.root, "alerts")
         self.alert_rules_path = alert_rules_path

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -172,7 +172,8 @@ class TestReloadAlertRules(unittest.TestCase):
     ALERT = yaml.safe_dump({"alert": "free_standing", "expr": "avg(some_vector[5m]) > 5"})
 
     def setUp(self):
-        # override the default ordering, since each of these steps depends on the state of the previous
+        # override the default ordering, since each of these steps depends on the
+        # state of the previous test
 
         # The "GIVEN" statements explicitly work against the way unittest is designed, and it is
         # only through sheer luck that they have worked thus far

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -61,7 +61,15 @@ class FakeConsumerCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self._port = 3100
+        self._stored.set_default(endpoint_events=0)
+
         self.loki_consumer = LokiPushApiConsumer(self)
+        self.framework.observe(
+            self.loki_consumer.on.loki_push_api_endpoint_joined, self.endpoint_events
+        )
+
+    def endpoint_events(self, _):
+        self._stored.endpoint_events += 1
 
     @property
     def _loki_push_api(self) -> str:
@@ -120,31 +128,34 @@ class TestLokiPushApiConsumer(unittest.TestCase):
             loki_push_api,
         )
 
-    @patch("charms.loki_k8s.v0.loki_push_api.LokiPushApiEvents.loki_push_api_endpoint_joined")
-    def test__on_upgrade_charm_endpoint_joined_event_fired_for_leader(self, mock_events):
+    def test__on_upgrade_charm_endpoint_joined_event_fired_for_leader(self):
         self.harness.set_leader(True)
 
         rel_id = self.harness.add_relation("logging", "promtail")
         self.harness.add_relation_unit(rel_id, "promtail/0")
+        self.assertEqual(self.harness.charm._stored.endpoint_events, 1)
+
         self.harness.update_relation_data(
             rel_id,
             "promtail",
             {"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
         )
-        mock_events.emit.assert_called_once()
 
-    @patch("charms.loki_k8s.v0.loki_push_api.LokiPushApiEvents.loki_push_api_endpoint_joined")
-    def test__on_upgrade_charm_endpoint_joined_event_fired_for_follower(self, mock_events):
+        self.assertEqual(self.harness.charm._stored.endpoint_events, 2)
+
+    def test__on_upgrade_charm_endpoint_joined_event_fired_for_follower(self):
         self.harness.set_leader(False)
 
         rel_id = self.harness.add_relation("logging", "promtail")
         self.harness.add_relation_unit(rel_id, "promtail/0")
+        self.assertEqual(self.harness.charm._stored.endpoint_events, 1)
+
         self.harness.update_relation_data(
             rel_id,
             "promtail",
             {"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
         )
-        mock_events.emit.assert_called_once()
+        self.assertEqual(self.harness.charm._stored.endpoint_events, 2)
 
 
 class TestReloadAlertRules(unittest.TestCase):
@@ -161,6 +172,11 @@ class TestReloadAlertRules(unittest.TestCase):
     ALERT = yaml.safe_dump({"alert": "free_standing", "expr": "avg(some_vector[5m]) > 5"})
 
     def setUp(self):
+        # override the default ordering, since each of these steps depends on the state of the previous
+
+        # The "GIVEN" statements explicitly work against the way unittest is designed, and it is
+        # only through sheer luck that they have worked thus far
+        unittest.TestLoader.sortTestMethodsUsing = None
         self.sandbox = TempFolderSandbox()
         alert_rules_path = os.path.join(self.sandbox.root, "alerts")
         self.alert_rules_path = alert_rules_path
@@ -190,7 +206,7 @@ class TestReloadAlertRules(unittest.TestCase):
 
         # need to manually emit relation changed
         # https://github.com/canonical/operator/issues/682
-        self.harness.charm.on.logging_relation_changed.emit(
+        self.harness.charm.on.logging_relation_joined.emit(
             self.harness.charm.model.get_relation("logging")
         )
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -149,6 +149,40 @@ class TestLokiPushApiProvider(unittest.TestCase):
                 )
             )
 
+    @patch(
+        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._generate_alert_rules_files",
+        MagicMock(),
+    )
+    @patch(
+        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._remove_alert_rules_files",
+        MagicMock(),
+    )
+    @patch(
+        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._regenerate_alert_rules",
+        MagicMock(),
+    )
+    @patch("ops.testing._TestingModelBackend.network_get")
+    def test__on_logging_relation_created_and_broken(self, mock_unit_ip):
+        fake_network = {
+            "bind-addresses": [
+                {
+                    "interface-name": "eth0",
+                    "addresses": [{"hostname": "loki-0", "value": "10.1.2.3"}],
+                }
+            ]
+        }
+        mock_unit_ip.return_value = fake_network
+        rel_id = self.harness.add_relation("logging", "promtail")
+        self.harness.add_relation_unit(rel_id, "promtail/0")
+
+        self.harness.update_relation_data(rel_id, "promtail", {"alert_rules": "ww"})
+        self.assertEqual(self.harness.charm.loki_provider._regenerate_alert_rules.call_count, 1)
+
+        self.harness.remove_relation(rel_id)
+        # This will be called once on depart and once on broken
+        # awaiting a cull of the mocking to look at the actual container
+        self.assertEqual(self.harness.charm.loki_provider._regenerate_alert_rules.call_count, 3)
+
     @patch("os.makedirs", MagicMock())
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_alerts(self, mock_unit_ip):


### PR DESCRIPTION
## Issue
Use of a common handler for virtually all relation events meant that there was a somewhat excessive amount of chatter between provider/consumer.

Move the relevant data/updates to the events they "belong to".

Closes #140 
Closes #65 

## Solution
Set relatively static data (alert rules, promtail_binary_url,
topology/metadata) in relation_joined. Fire events on
relation-changed so endpoints are still updated.

Streamline event handling.

Remove more mocking.

Make the state-dependent unit tests for reloading alert rules
explicitly ignore sorting. Unittests should:

* Be in a `unittest.TestSuite` if ordering matters
* Not be dependent on the order of previous tests, since `unittest` sorts (by default) using `dir()` and alphabetic sorting. Making functions "digestible" at the cost of predictability is not worth it

## Context
We all know the common exithook.

## Testing Instructions
Unit+integration tests

## Release Notes
Remove common exit hook from loki_push_api
