### PR TITLE
Add unit tests for startup events ordering

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,8 +19,6 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          fail-build: true
-          comment-on-pr: false
 
   static-libs:
     name: Static analysis of /lib for Python 3.5

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          fail-build: true
+          comment-on-pr: false
 
   static-libs:
     name: Static analysis of /lib for Python 3.5

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
+        continue-on-error: true
         uses: canonical/charming-actions/check-libraries@1.0.1-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        continue-on-error: true
         uses: canonical/charming-actions/check-libraries@1.0.1-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1832,7 +1832,9 @@ class LogProxyConsumer(ConsumerBase):
         else:
             new_config = self._promtail_config
             if new_config != self._current_config:
-                self._container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config))
+                self._container.push(
+                    WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True
+                )
                 self._container.restart(WORKLOAD_SERVICE_NAME)
                 self.on.log_proxy_endpoint_joined.emit()
 
@@ -1850,7 +1852,7 @@ class LogProxyConsumer(ConsumerBase):
 
         new_config = self._promtail_config
         if new_config != self._current_config:
-            self._container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config))
+            self._container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True)
 
         if new_config["clients"]:
             self._container.restart(WORKLOAD_SERVICE_NAME)

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class LokiOperatorCharm(CharmBase):
         try:
             if yaml.safe_load(self._stored.config) != config:
                 config_as_yaml = yaml.safe_dump(config)
-                self._container.push(LOKI_CONFIG, config_as_yaml)
+                self._container.push(LOKI_CONFIG, config_as_yaml, make_dirs=True)
                 logger.info("Pushed new configuration")
                 self._stored.config = config_as_yaml
                 restart = True

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -8,6 +8,10 @@ from typing import Callable, Tuple
 from unittest.mock import patch
 
 
+def tautology(*args, **kwargs) -> bool:
+    return True
+
+
 def patch_network_get(private_address="10.1.157.116") -> Callable:
     def network_get(*args, **kwargs) -> dict:
         """Patch for the not-yet-implemented testing backend needed for `bind_address`.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,7 +4,30 @@
 
 import os
 import tempfile
-from typing import Tuple
+from typing import Callable, Tuple
+from unittest.mock import patch
+
+
+def patch_network_get(private_address="10.1.157.116") -> Callable:
+    def network_get(*args, **kwargs) -> dict:
+        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
+
+        This patch decorator can be used for cases such as:
+        self.model.get_binding(event.relation).network.bind_address
+        """
+        return {
+            "bind-addresses": [
+                {
+                    "mac-address": "",
+                    "interface-name": "",
+                    "addresses": [{"hostname": "", "value": private_address, "cidr": ""}],
+                }
+            ],
+            "egress-subnets": ["10.152.183.65/32"],
+            "ingress-addresses": ["10.152.183.65"],
+        }
+
+    return patch("ops.testing._TestingModelBackend.network_get", network_get)
 
 
 class TempFolderSandbox:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -166,6 +166,14 @@ class TestConfigFile(unittest.TestCase):
         config = yaml.safe_load(container.pull(LOKI_CONFIG_PATH))
         self.assertEqual(config["ruler"]["alertmanager_url"], None)
 
+    def test_instance_address_is_set_to_this_unit_ip(self):
+        container = self.harness.charm.unit.get_container("loki")
+        config = yaml.safe_load(container.pull(LOKI_CONFIG_PATH))
+
+        # TODO enable this assertion when the following is resolved
+        # https://github.com/canonical/loki-k8s-operator/issues/159
+        # self.assertEqual(config["common"]["ring"]["instance_addr"], "1.1.1.1")
+
 
 class TestDelayedPebbleReady(unittest.TestCase):
     """Feature: Charm code must be resilient to any (reasonable) order of startup event firing."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -163,6 +163,7 @@ class TestDelayedPebbleReady(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def setUp(self):
+        # Path _check_alert_rules, which attempts to talk to a loki server endpoint
         self.check_alert_rules_patcher = patch(
             "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._check_alert_rules",
             new=tautology,
@@ -178,7 +179,6 @@ class TestDelayedPebbleReady(unittest.TestCase):
         self.harness.add_relation_unit(self.log_rel_id, "consumer-app/0")
         self.harness.add_relation_unit(self.log_rel_id, "consumer-app/1")
         self.harness.begin_with_initial_hooks()
-        # self.harness.charm.loki_provider._check_alert_rules = tautology
         self.harness.update_relation_data(
             self.log_rel_id,
             "consumer-app",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,69 +12,11 @@ from helpers import patch_network_get, tautology
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
-from charm import LokiOperatorCharm
 from charm import LOKI_CONFIG as LOKI_CONFIG_PATH
+from charm import LokiOperatorCharm
 from loki_server import LokiServerError, LokiServerNotReadyError
 
 ops.testing.SIMULATE_CAN_CONNECT = True
-
-LOKI_CONFIG = """
-auth_enabled: false
-chunk_store_config:
-  max_look_back_period: 0s
-compactor:
-  shared_store: filesystem
-  working_directory: /loki/boltdb-shipper-compactor
-ingester:
-  chunk_idle_period: 1h
-  chunk_retain_period: 30s
-  chunk_target_size: 1048576
-  lifecycler:
-    address: 127.0.0.1
-    final_sleep: 0s
-    ring:
-      kvstore:
-        store: inmemory
-      replication_factor: 1
-  max_chunk_age: 1h
-  max_transfer_retries: 0
-limits_config:
-  reject_old_samples: true
-  reject_old_samples_max_age: 168h
-ruler:
-  alertmanager_url: ''
-  enable_api: true
-  ring:
-    kvstore:
-      store: inmemory
-  rule_path: /loki/rules-temp
-  storage:
-    local:
-      directory: /loki/rules
-    type: local
-schema_config:
-  configs:
-  - from: 2020-10-24
-    index:
-      period: 24h
-      prefix: index_
-    object_store: filesystem
-    schema: v11
-    store: boltdb-shipper
-server:
-  http_listen_port: 3100
-storage_config:
-  boltdb_shipper:
-    active_index_directory: /loki/boltdb-shipper-active
-    cache_location: /loki/boltdb-shipper-cache
-    cache_ttl: 24h
-    shared_store: filesystem
-  filesystem:
-    directory: /loki/chunks
-table_manager:
-  retention_deletes_enabled: false
-  retention_period: 0s
-"""
 
 
 class TestWorkloadUnavailable(unittest.TestCase):
@@ -90,7 +32,6 @@ class TestWorkloadUnavailable(unittest.TestCase):
         self.addCleanup(version_patcher.stop)
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
-        self.harness.charm._stored.config = LOKI_CONFIG
         self.harness.container_pebble_ready("loki")
 
     def test__provide_loki_not_ready(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -162,10 +162,12 @@ class TestDelayedPebbleReady(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
-    @patch(
-        "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._check_alert_rules", new=tautology
-    )
     def setUp(self):
+        self.check_alert_rules_patcher = patch(
+            "charms.loki_k8s.v0.loki_push_api.LokiPushApiProvider._check_alert_rules",
+            new=tautology,
+        )
+        self.check_alert_rules_patcher.start()
         self.harness = Harness(LokiOperatorCharm)
 
         # GIVEN this unit is the leader
@@ -185,6 +187,9 @@ class TestDelayedPebbleReady(unittest.TestCase):
                 "alert_rules": {},
             },
         )
+
+    def tearDown(self):
+        self.check_alert_rules_patcher.stop()
 
     def test_regular_relation_departed_runs_before_pebble_ready(self):
         """Scenario: a regular relation is removed quickly, before pebble-ready fires."""


### PR DESCRIPTION
## Issue
Closes #75 


## Solution
Write unit tests to address scenario.


## Testing Instructions
`tox -e unit -- -k TestDelayedPebbleReady`


## Release Notes
Add unit tests for startup event ordering.

Crossref: [OPENG-402](https://warthogs.atlassian.net/browse/OPENG-402)
