### PR TITLE
Use cos-tool to transform/validate, use JujuTopology from observability libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ __pycache__
 build
 venv
 .tox
-tests/integration/loki-tester/lib/charms/
-tests/integration/log-proxy-tester/lib/charms/
+tests/integration/loki-tester/lib/charms/loki_k8s
+tests/integration/log-proxy-tester/lib/charms/loki_k8s
 cos-tool*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 .tox
 tests/integration/loki-tester/lib/charms/
 tests/integration/log-proxy-tester/lib/charms/
+cos-tool*

--- a/.jujuignore
+++ b/.jujuignore
@@ -2,3 +2,4 @@
 *.py[cod]
 *.charm
 .#*
+cos-tool*

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,3 +11,11 @@ bases:
 parts:
   charm:
     build-packages: [git]
+  cos-tool:
+    plugin: dump
+    source: .
+    build-packages:
+      - curl
+    override-pull: |
+      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
+      chmod +x cos-tool-*

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -441,18 +441,21 @@ import os
 import platform
 import re
 import socket
+import subprocess
+import tempfile
 import typing
-from collections import OrderedDict
+import uuid
 from copy import deepcopy
 from gzip import GzipFile
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
-from typing import Dict, List, Optional, Union, cast
+from typing import Dict, List, Optional, Tuple, Union, cast
 from urllib import request
 from urllib.error import HTTPError
 
 import yaml
+from charms.observability_libs.v0.juju_topology import JujuTopology
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -617,205 +620,6 @@ def _validate_relation_by_interface_and_direction(
         raise Exception("Unexpected RelationDirection: {}".format(expected_relation_role))
 
 
-class JujuTopology:
-    """Class for storing and formatting juju topology information."""
-
-    STUB = "%%juju_topology%%"
-
-    def __new__(cls, *args, **kwargs):
-        """Reject instantiation of a base JujuTopology class. Children only."""
-        if cls is JujuTopology:
-            raise TypeError("only children of '{}' may be instantiated".format(cls.__name__))
-        return object.__new__(cls)
-
-    def __init__(
-        self,
-        model: str,
-        model_uuid: str,
-        application: str,
-        unit: Optional[str] = "",
-        charm_name: Optional[str] = "",
-    ):
-        """Build a JujuTopology object.
-
-        A `JujuTopology` object is used for storing and transforming
-        Juju Topology information. This information is used to
-        annotate Prometheus scrape jobs and alert rules. Such
-        annotation when applied to scrape jobs helps in identifying
-        the source of the scrapped metrics. On the other hand when
-        applied to alert rules topology information ensures that
-        evaluation of alert expressions is restricted to the source
-        (charm) from which the alert rules were obtained.
-
-        Args:
-            model: a string name of the Juju model
-            model_uuid: a globally unique string identifier for the Juju model
-            application: an application name as a string
-            unit: a unit name as a string
-            charm_name: name of charm as a string
-
-        Note:
-            `JujuTopology` should not be constructed directly by charm code. Please
-            use `ProviderTopology` or `AggregatorTopology`.
-        """
-        self.model = model
-        self.model_uuid = model_uuid
-        self.application = application
-        self.charm_name = charm_name
-        self.unit = unit
-
-    @classmethod
-    def from_charm(cls, charm):
-        """Factory method for creating `JujuTopology` children from a given charm.
-
-        Args:
-            charm: a `CharmBase` object for which the `JujuTopology` has to be constructed
-
-        Returns:
-            a `JujuTopology` object.
-        """
-        return cls(
-            model=charm.model.name,
-            model_uuid=charm.model.uuid,
-            application=charm.model.app.name,
-            unit=charm.model.unit.name,
-            charm_name=charm.meta.name,
-        )
-
-    @classmethod
-    def from_relation_data(cls, data: dict):
-        """Factory method for creating `JujuTopology` children from a dictionary.
-
-        Args:
-            data: a dictionary with four keys providing topology information. The keys are
-                - "model"
-                - "model_uuid"
-                - "application"
-                - "unit"
-                - "charm_name"
-
-                `unit` and `charm_name` may be empty, but will result in more limited
-                labels. However, this allows us to support payload-only charms.
-
-        Returns:
-            a `JujuTopology` object.
-        """
-        return cls(
-            model=data["model"],
-            model_uuid=data["model_uuid"],
-            application=data["application"],
-            unit=data.get("unit", ""),
-            charm_name=data.get("charm_name", ""),
-        )
-
-    @property
-    def identifier(self) -> str:
-        """Format the topology information into a terse string."""
-        # This is odd, but may have `None` as a model key
-        return "_".join([str(val) for val in self.as_promql_label_dict().values()]).replace(
-            "/", "_"
-        )
-
-    @property
-    def promql_labels(self) -> str:
-        """Format the topology information into a verbose string."""
-        return ", ".join(
-            ['{}="{}"'.format(key, value) for key, value in self.as_promql_label_dict().items()]
-        )
-
-    def as_dict(self, rename_keys: Optional[Dict[str, str]] = None) -> OrderedDict:
-        """Format the topology information into a dict.
-
-        Use an OrderedDict so we can rely on the insertion order on Python 3.5 (and 3.6,
-        which still does not guarantee it).
-
-        Args:
-            rename_keys: A dictionary mapping old key names to new key names, which will
-                be substituted when invoked.
-        """
-        ret = OrderedDict(
-            [
-                ("model", self.model),
-                ("model_uuid", self.model_uuid),
-                ("application", self.application),
-                ("unit", self.unit),
-                ("charm_name", self.charm_name),
-            ]
-        )
-
-        ret["unit"] or ret.pop("unit")
-        ret["charm_name"] or ret.pop("charm_name")
-
-        # If a key exists in `rename_keys`, replace the value
-        if rename_keys:
-            ret = OrderedDict(
-                (rename_keys.get(k), v) if rename_keys.get(k) else (k, v) for k, v in ret.items()  # type: ignore
-            )
-
-        return ret
-
-    def as_label_dict(self):
-        """Format the topology information into a dict with keys having 'juju_' as prefix."""
-        vals = {
-            "juju_{}".format(key): val
-            for key, val in self.as_dict(rename_keys={"charm_name": "charm"}).items()
-        }
-        return vals
-
-    def as_promql_label_dict(self):
-        """Format the topology information into a dict with keys having 'juju_' as prefix."""
-        vals = self.as_label_dict()
-        # The leader is the only unit that sets alert rules, if "juju_unit" is present,
-        # then the rules will only be evaluated for that unit
-        if "juju_unit" in vals:
-            vals.pop("juju_unit")
-
-        return vals
-
-    def render(self, template: str):
-        """Render a juju-topology template string with topology info."""
-        return template.replace(JujuTopology.STUB, self.promql_labels)
-
-
-class AggregatorTopology(JujuTopology):
-    """Class for initializing topology information for MetricsEndpointAggregator."""
-
-    @classmethod
-    def create(
-        cls, model: str, model_uuid: str, application: str, unit: str
-    ) -> "AggregatorTopology":
-        """Factory method for creating the `AggregatorTopology` dataclass from a given charm.
-
-        Args:
-            model: a string representing the model
-            model_uuid: the model UUID as a string
-            application: the application name
-            unit: the unit name
-
-        Returns:
-            a `AggregatorTopology` object.
-        """
-        return cls(
-            model=model,
-            model_uuid=model_uuid,
-            application=application,
-            unit=unit,
-        )
-
-
-class ProviderTopology(JujuTopology):
-    """Class for initializing topology information for MetricsEndpointProvider."""
-
-    @property
-    def scrape_identifier(self) -> str:
-        """Format the topology information into a scrape identifier."""
-        # This is used only by Metrics[Consumer|Provider] and does not need a
-        # unit name, so only check for the charm name
-        return "juju_{}_prometheus_scrape".format(
-            "_".join([self.model, self.model_uuid[:7], self.application, self.charm_name])  # type: ignore
-        )
-
-
 class InvalidAlertRulePathError(Exception):
     """Raised if the alert rules folder cannot be found or is otherwise invalid."""
 
@@ -901,6 +705,7 @@ class AlertRules:
             topology: a `JujuTopology` instance that is used to annotate all alert rules.
         """
         self.topology = topology
+        self.tool = CosTool(None)
         self.alert_groups = []  # type: List[dict]
 
     def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
@@ -950,9 +755,15 @@ class AlertRules:
                         alert_rule["labels"] = {}
 
                     if self.topology:
-                        alert_rule["labels"].update(self.topology.as_promql_label_dict())
+                        alert_rule["labels"].update(self.topology.label_matcher_dict)
                         # insert juju topology filters into a prometheus alert rule
-                        alert_rule["expr"] = self.topology.render(alert_rule["expr"])
+                        # logql doesn't like empty matchers, so add a job matcher which hits
+                        # any string as a "wildcard" which the topology labels will
+                        # filter down
+                        alert_rule["expr"] = self.tool.inject_label_matchers(
+                            re.sub(r"%%juju_topology%%(,?)", r'job=".+"\1', alert_rule["expr"]),
+                            self.topology.label_matcher_dict,
+                        )
 
             return alert_groups
 
@@ -1204,12 +1015,37 @@ class LokiPushApiAlertRulesChanged(EventBase):
             self.unit = None
 
 
+class InvalidAlertRuleEvent(EventBase):
+    """Event emitted when alert rule files are not parsable.
+
+    Enables us to set a clear status on the provider.
+    """
+
+    def __init__(self, handle, errors: str = "", valid: bool = False):
+        super().__init__(handle)
+        self.errors = errors
+        self.valid = valid
+
+    def snapshot(self) -> Dict:
+        """Save alert rule information."""
+        return {
+            "valid": self.valid,
+            "errors": self.errors,
+        }
+
+    def restore(self, snapshot):
+        """Restore alert rule information."""
+        self.valid = snapshot["valid"]
+        self.errors = snapshot["errors"]
+
+
 class LokiPushApiEvents(ObjectEvents):
     """Event descriptor for events raised by `LokiPushApiProvider`."""
 
     loki_push_api_endpoint_departed = EventSource(LokiPushApiEndpointDeparted)
     loki_push_api_endpoint_joined = EventSource(LokiPushApiEndpointJoined)
     loki_push_api_alert_rules_changed = EventSource(LokiPushApiAlertRulesChanged)
+    alert_rule_status_changed = EventSource(InvalidAlertRuleEvent)
 
 
 class LokiPushApiProvider(Object):
@@ -1254,6 +1090,7 @@ class LokiPushApiProvider(Object):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
+        self._tool = CosTool(self)
         self.port = int(port)
         self.container = self._charm._container
         self.scheme = scheme
@@ -1431,7 +1268,7 @@ class LokiPushApiProvider(Object):
         return {"url": url.rstrip("/") + endpoint}
 
     @property
-    def alerts(self) -> dict:
+    def alerts(self) -> dict:  # noqa: C901
         """Fetch alerts for all relations.
 
         A Loki alert rules file consists of a list of "groups". Each
@@ -1472,12 +1309,20 @@ class LokiPushApiProvider(Object):
             if not alert_rules:
                 continue
 
+            errors = []
             try:
                 # NOTE: this `metadata` key SHOULD NOT be changed to `scrape_metadata`
                 # to align with Prometheus without careful consideration'
                 metadata = json.loads(relation.data[relation.app]["metadata"])
-                identifier = ProviderTopology.from_relation_data(metadata).identifier
-                alerts[identifier] = alert_rules
+                identifier = JujuTopology.from_dict(metadata).identifier
+                labeled_alerts = self._tool.apply_label_matchers(alert_rules)
+
+                _, errmsg = self._tool.validate_alert_rules(alert_rules)
+                if errmsg:
+                    errors.append(errmsg)
+                    continue
+
+                alerts[identifier] = labeled_alerts
             except KeyError as e:
                 logger.warning(
                     "Relation %s has no 'metadata': %s",
@@ -1497,9 +1342,17 @@ class LokiPushApiProvider(Object):
                             labels["juju_model_uuid"],
                             labels["juju_application"],
                         )
+
+                        _, errmsg = self._tool.validate_alert_rules(alert_rules)
+                        if errmsg:
+                            errors.append(errmsg)
+                            continue
+
                         alerts[identifier] = alert_rules
                     except KeyError:
                         logger.error("Alert rules were found but no usable labels were present")
+            if errors:
+                relation.data[self._charm.app]["event"] = json.dumps({"errors": "; ".join(errors)})
 
         return alerts
 
@@ -1517,7 +1370,7 @@ class ConsumerBase(Object):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
-        self.topology = ProviderTopology.from_charm(charm)
+        self.topology = JujuTopology.from_charm(charm)
 
         try:
             alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
@@ -1665,7 +1518,7 @@ class LokiPushApiConsumer(ConsumerBase):
         self._handle_alert_rules(event.relation)
         self.on.loki_push_api_endpoint_joined.emit()
 
-    def _on_logging_relation_changed(self, _: RelationEvent):
+    def _on_logging_relation_changed(self, event: RelationEvent):
         """Handle changes in related consumers.
 
         Anytime there are changes in the relation between Loki
@@ -1680,6 +1533,18 @@ class LokiPushApiConsumer(ConsumerBase):
             loki_push_api_alert_rules_error: This event is emitted when an invalid alert rules
                 file is encountered or if `alert_rules_path` is empty.
         """
+        if self._charm.unit.is_leader():
+            ev = json.loads(event.relation.data[event.app].get("event", "{}"))
+
+            if ev:
+                valid = bool(ev.get("valid", True))
+                errors = ev.get("errors", "")
+
+                if valid and not errors:
+                    self.on.alert_rule_status_changed.emit(valid=valid)
+                else:
+                    self.on.alert_rule_status_changed.emit(valid=valid, errors=errors)
+
         self.on.loki_push_api_endpoint_joined.emit()
 
     def _reinitialize_alert_rules(self):
@@ -1823,7 +1688,7 @@ class LogProxyConsumer(ConsumerBase):
         self._log_files = log_files or []
         self._syslog_port = syslog_port
         self._is_syslog = enable_syslog
-        self.topology = ProviderTopology.from_charm(charm)
+        self.topology = JujuTopology.from_charm(charm)
         self._promtail_resource_name = promtail_resource_name or "promtail-bin"
 
         # architechure used for promtail binary
@@ -1859,6 +1724,18 @@ class LogProxyConsumer(ConsumerBase):
             event: The event object `RelationChangedEvent`.
         """
         self._handle_alert_rules(event.relation)
+
+        if self._charm.unit.is_leader():
+            ev = json.loads(event.relation.data[event.app].get("event", "{}"))
+
+            if ev:
+                valid = bool(ev.get("valid", True))
+                errors = ev.get("errors", "")
+
+                if valid and not errors:
+                    self.on.alert_rule_status_changed.emit(valid=valid)
+                else:
+                    self.on.alert_rule_status_changed.emit(valid=valid, errors=errors)
 
         if not self._container.can_connect():
             return
@@ -2216,7 +2093,12 @@ class LogProxyConsumer(ConsumerBase):
             A dict representing the `scrape_configs` section.
         """
         job_name = "juju_{}".format(self.topology.identifier)
-        common_labels = self.topology.as_label_dict()
+
+        # The new JujuTopology doesn't include unit, but LogProxyConsumer should have it
+        common_labels = {
+            "juju_{}".format(k): v
+            for k, v in self.topology.as_dict(remapped_keys={"charm_name": "charm"}).items()
+        }
         scrape_configs = []
 
         # Files config
@@ -2345,3 +2227,122 @@ class LogProxyConsumer(ConsumerBase):
         return 'action(type="omfwd" protocol="tcp" target="127.0.0.1" port="{}" Template="RSYSLOG_SyslogProtocol23Format" TCP_Framing="octet-counted")'.format(
             self._syslog_port
         )
+
+
+class CosTool:
+    """Uses cos-tool to inject label matchers into alert rule expressions and validate rules."""
+
+    _path = None
+    _disabled = False
+
+    def __init__(self, charm):
+        self._charm = charm
+
+    @property
+    def path(self):
+        """Lazy lookup of the path of cos-tool."""
+        if self._disabled:
+            return None
+        if not self._path:
+            self._path = self._get_tool_path()
+            if not self._path:
+                logger.debug("Skipping injection of juju topology as label matchers")
+                self._disabled = True
+        return self._path
+
+    def apply_label_matchers(self, rules) -> dict:
+        """Will apply label matchers to the expression of all alerts in all supplied groups."""
+        if not self.path:
+            return rules
+        for group in rules["groups"]:
+            rules_in_group = group.get("rules", [])
+            for rule in rules_in_group:
+                topology = {}
+                # if the user for some reason has provided juju_unit, we'll need to honor it
+                # in most cases, however, this will be empty
+                for label in [
+                    "juju_model",
+                    "juju_model_uuid",
+                    "juju_application",
+                    "juju_charm",
+                    "juju_unit",
+                ]:
+                    if label in rule["labels"]:
+                        topology[label] = rule["labels"][label]
+
+                rule["expr"] = self.inject_label_matchers(rule["expr"], topology)
+        return rules
+
+    def validate_alert_rules(self, rules: dict) -> Tuple[bool, str]:
+        """Will validate correctness of alert rules, returning a boolean and any errors."""
+        if not self.path:
+            logger.debug("`cos-tool` unavailable. Not validating alert correctness.")
+            return True, ""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rule_path = Path(tmpdir + "/validate_rule.yaml")
+
+            # Smash "our" rules format into what upstream actually uses, which is more like:
+            #
+            # groups:
+            #   - name: foo
+            #     rules:
+            #       - alert: SomeAlert
+            #         expr: up
+            #       - alert: OtherAlert
+            #         expr: up
+            transformed_rules = {"groups": []}  # type: ignore
+            for rule in rules["groups"]:
+                transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
+                transformed_rules["groups"].append(transformed)
+
+            rule_path.write_text(yaml.dump(transformed_rules))
+
+            args = [str(self.path), "--format", "logql", "validate", str(rule_path)]
+            # noinspection PyBroadException
+            try:
+                self._exec(args)
+                return True, ""
+            except subprocess.CalledProcessError as e:
+                logger.debug("Validating the rules failed: %s", e.output)
+                return False, ", ".join([line for line in e.output if "error validating" in line])
+
+    def inject_label_matchers(self, expression, topology) -> str:
+        """Add label matchers to an expression."""
+        if not topology:
+            return expression
+        if not self.path:
+            logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
+            return expression
+        args = [str(self.path), "--format", "logql", "transform"]
+        args.extend(
+            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
+        )
+
+        args.extend(["{}".format(expression)])
+        # noinspection PyBroadException
+        try:
+            return self._exec(args)
+        except subprocess.CalledProcessError as e:
+            logger.debug('Applying the expression failed: "%s", falling back to the original', e)
+            print('Applying the expression failed: "{}", falling back to the original'.format(e))
+            return expression
+
+    def _get_tool_path(self) -> Optional[Path]:
+        arch = platform.processor()
+        arch = "amd64" if arch == "x86_64" else arch
+        res = "cos-tool-{}".format(arch)
+        try:
+            path = Path(res).resolve()
+            path.chmod(0o777)
+            return path
+        except NotImplementedError:
+            logger.debug("System lacks support for chmod")
+        except FileNotFoundError:
+            logger.debug('Could not locate cos-tool at: "{}"'.format(res))
+        return None
+
+    def _exec(self, cmd) -> str:
+        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
+        output = result.stdout.decode("utf-8").strip()
+        return output

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -766,7 +766,7 @@ class AlertRules:
                         # any string as a "wildcard" which the topology labels will
                         # filter down
                         alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%(,?)", r'job=".+"\1', alert_rule["expr"]),
+                            re.sub(r"%%juju_topology%%", r'job=".+"', alert_rule["expr"]),
                             self.topology.label_matcher_dict,
                         )
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -156,6 +156,11 @@ This Loki charm interacts with its clients using the Loki charm library. Charms
 seeking to send log to Loki, must do so using the `LokiPushApiConsumer` object from
 this charm library.
 
+> **NOTE**: `LokiPushApiConsumer` also depends on an additional charm library.
+>
+> Ensure sure you `charmcraft fetch-lib charms.observability_libs.v0.juju_topology`
+> when using this library.
+
 For the simplest use cases, using the `LokiPushApiConsumer` object only requires
 instantiating it, typically in the constructor of your charm (the one which
 sends logs).

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -1,0 +1,288 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""## Overview.
+
+This document explains how to use the `JujuTopology` class to
+create and consume topology information from Juju in a consistent manner.
+
+The goal of the Juju topology is to uniquely identify a piece
+of software running across any of your Juju-managed deployments.
+This is achieved by combining the following four elements:
+
+- Model name
+- Model UUID
+- Application name
+- Unit identifier
+
+
+For a more in-depth description of the concept, as well as a
+walk-through of it's use-case in observability, see
+[this blog post](https://juju.is/blog/model-driven-observability-part-2-juju-topology-metrics)
+on the Juju blog.
+
+## Library Usage
+
+This library may be used to create and consume `JujuTopology` objects.
+The `JujuTopology` class provides three ways to create instances:
+
+### Using the `from_charm` method
+
+Enables instantiation by supplying the charm as an argument. When
+creating topology objects for the current charm, this is the recommended
+approach.
+
+```python
+topology = JujuTopology.from_charm(self)
+```
+
+### Using the `from_dict` method
+
+Allows for instantion using a dictionary of relation data, like the
+`scrape_metadata` from Prometheus or the labels of an alert rule. When
+creating topology objects for remote charms, this is the recommended
+approach.
+
+```python
+scrape_metadata = json.loads(relation.data[relation.app].get("scrape_metadata", "{}"))
+topology = JujuTopology.from_dict(scrape_metadata)
+```
+
+### Using the class constructor
+
+Enables instantiation using whatever values you want. While this
+is useful in some very specific cases, this is almost certainly not
+what you are looking for as setting these values manually may
+result in observability metrics which do not uniquely identify a
+charm in order to provide accurate usage reporting, alerting,
+horizontal scaling, or other use cases.
+
+```python
+topology = JujuTopology(
+    model="some-juju-model",
+    model_uuid="00000000-0000-0000-0000-000000000001",
+    application="fancy-juju-application",
+    unit="fancy-juju-application/0",
+    charm_name="fancy-juju-application-k8s",
+)
+```
+
+"""
+
+import re
+from collections import OrderedDict
+from typing import Dict, List, Optional
+
+# The unique Charmhub library identifier, never change it
+LIBID = "bced1658f20f49d28b88f61f83c2d232"
+
+LIBAPI = 0
+LIBPATCH = 1
+
+
+class InvalidUUIDError(Exception):
+    """Invalid UUID was provided."""
+
+    def __init__(self, uuid: str):
+        self.message = "'{}' is not a valid UUID.".format(uuid)
+        super().__init__(self.message)
+
+
+class JujuTopology:
+    """JujuTopology is used for storing, generating and formatting juju topology information."""
+
+    def __init__(
+        self,
+        model: str,
+        model_uuid: str,
+        application: str,
+        unit: str = None,
+        charm_name: str = None,
+    ):
+        """Build a JujuTopology object.
+
+        A `JujuTopology` object is used for storing and transforming
+        Juju topology information. This information is used to
+        annotate Prometheus scrape jobs and alert rules. Such
+        annotation when applied to scrape jobs helps in identifying
+        the source of the scrapped metrics. On the other hand when
+        applied to alert rules topology information ensures that
+        evaluation of alert expressions is restricted to the source
+        (charm) from which the alert rules were obtained.
+
+        Args:
+            model: a string name of the Juju model
+            model_uuid: a globally unique string identifier for the Juju model
+            application: an application name as a string
+            unit: a unit name as a string
+            charm_name: name of charm as a string
+        """
+        if not self.is_valid_uuid(model_uuid):
+            raise InvalidUUIDError(model_uuid)
+
+        self._model = model
+        self._model_uuid = model_uuid
+        self._application = application
+        self._charm_name = charm_name
+        self._unit = unit
+
+    def is_valid_uuid(self, uuid):
+        """Validates the supplied UUID against the Juju Model UUID pattern."""
+        regex = re.compile(
+            "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
+        )
+        return bool(regex.match(uuid))
+
+    @classmethod
+    def from_charm(cls, charm):
+        """Creates a JujuTopology instance by using the model data available on a charm object.
+
+        Args:
+            charm: a `CharmBase` object for which the `JujuTopology` will be constructed
+        Returns:
+            a `JujuTopology` object.
+        """
+        return cls(
+            model=charm.model.name,
+            model_uuid=charm.model.uuid,
+            application=charm.model.app.name,
+            unit=charm.model.unit.name,
+            charm_name=charm.meta.name,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Factory method for creating `JujuTopology` children from a dictionary.
+
+        Args:
+            data: a dictionary with five keys providing topology information. The keys are
+                - "model"
+                - "model_uuid"
+                - "application"
+                - "unit"
+                - "charm_name"
+                `unit` and `charm_name` may be empty, but will result in more limited
+                labels. However, this allows us to support charms without workloads.
+
+        Returns:
+            a `JujuTopology` object.
+        """
+        return cls(
+            model=data["model"],
+            model_uuid=data["model_uuid"],
+            application=data["application"],
+            unit=data.get("unit", ""),
+            charm_name=data.get("charm_name", ""),
+        )
+
+    def as_dict(
+        self, *, remapped_keys: Dict[str, str] = None, excluded_keys: List[str] = None
+    ) -> OrderedDict:
+        """Format the topology information into an ordered dict.
+
+        Keeping the dictionary ordered is important to be able to
+        compare dicts without having to resort to deep comparisons.
+
+        Args:
+            remapped_keys: A dictionary mapping old key names to new key names,
+                which will be substituted when invoked.
+            excluded_keys: A list of key names to exclude from the returned dict.
+            uuid_length: The length to crop the UUID to.
+        """
+        ret = OrderedDict(
+            [
+                ("model", self.model),
+                ("model_uuid", self.model_uuid),
+                ("application", self.application),
+                ("unit", self.unit),
+                ("charm_name", self.charm_name),
+            ]
+        )
+        if excluded_keys:
+            ret = OrderedDict({k: v for k, v in ret.items() if k not in excluded_keys})
+
+        if remapped_keys:
+            ret = OrderedDict(
+                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v) for k, v in ret.items()  # type: ignore
+            )
+
+        return ret
+
+    @property
+    def identifier(self) -> str:
+        """Format the topology information into a terse string.
+
+        This crops the model UUID, making it unsuitable for comparisons against
+        anything but other identifiers. Mainly to be used as a display name or file
+        name where long strings might become an issue.
+
+        >>> JujuTopology( \
+              model = "a-model", \
+              model_uuid = "00000000-0000-4000-8000-000000000000", \
+              application = "some-app", \
+              unit = "some-app/1" \
+            ).identifier
+        'a-model_00000000_some-app'
+        """
+        parts = self.as_dict(
+            excluded_keys=["unit", "charm_name"],
+        )
+
+        parts["model_uuid"] = self.model_uuid_short
+        values = parts.values()
+
+        return "_".join([str(val) for val in values]).replace("/", "_")
+
+    @property
+    def label_matcher_dict(self) -> Dict[str, str]:
+        """Format the topology information into a dict with keys having 'juju_' as prefix.
+
+        Relabelled topology never includes the unit as it would then only match
+        the leader unit (ie. the unit that produced the dict).
+        """
+        items = self.as_dict(
+            remapped_keys={"charm_name": "charm"},
+            excluded_keys=["unit"],
+        ).items()
+
+        return {"juju_{}".format(key): value for key, value in items if value}
+
+    @property
+    def label_matchers(self) -> str:
+        """Format the topology information into a promql/logql label matcher string.
+
+        Topology label matchers should never include the unit as it
+        would then only match the leader unit (ie. the unit that
+        produced the matchers).
+        """
+        items = self.label_matcher_dict.items()
+        return ", ".join(['{}="{}"'.format(key, value) for key, value in items if value])
+
+    @property
+    def model(self) -> str:
+        """Getter for the juju model value."""
+        return self._model
+
+    @property
+    def model_uuid(self) -> str:
+        """Getter for the juju model uuid value."""
+        return self._model_uuid
+
+    @property
+    def model_uuid_short(self) -> str:
+        """Getter for the juju model value, truncated to the first eight letters."""
+        return self._model_uuid[:8]
+
+    @property
+    def application(self) -> str:
+        """Getter for the juju application value."""
+        return self._application
+
+    @property
+    def charm_name(self) -> Optional[str]:
+        """Getter for the juju charm name value."""
+        return self._charm_name
+
+    @property
+    def unit(self) -> Optional[str]:
+        """Getter for the juju unit value."""
+        return self._unit

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -76,7 +76,7 @@ from typing import Dict, List, Optional
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 class InvalidUUIDError(Exception):
@@ -126,9 +126,27 @@ class JujuTopology:
         self._unit = unit
 
     def is_valid_uuid(self, uuid):
-        """Validates the supplied UUID against the Juju Model UUID pattern."""
+        """Validate the supplied UUID against the Juju Model UUID pattern."""
+        # TODO:
+        # Harness is harcoding an UUID that is v1 not v4: f2c1b2a6-e006-11eb-ba80-0242ac130004
+        # See: https://github.com/canonical/operator/issues/779
+        #
+        # >>> uuid.UUID("f2c1b2a6-e006-11eb-ba80-0242ac130004").version
+        # 1
+        #
+        # we changed the validation of the 3ed UUID block: 4[a-f0-9]{3} -> [a-f0-9]{4}
+        # See: https://github.com/canonical/operator/blob/main/ops/testing.py#L1094
+        #
+        # Juju in fact generates a UUID v4: https://github.com/juju/utils/blob/master/uuid.go#L62
+        # but does not validate it is actually v4:
+        # See:
+        # - https://github.com/juju/utils/blob/master/uuid.go#L22
+        # - https://github.com/juju/schema/blob/master/strings.go#L79
+        #
+        # Once Harness fixes this, we should remove this comment and refactor the regex or
+        # the entire method using the uuid module to validate UUIDs
         regex = re.compile(
-            "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
+            "^[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
         )
         return bool(regex.match(uuid))
 

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -10,8 +10,6 @@ ingress.
 ## Getting Started
 
 To get started using the library, you just need to fetch the library using `charmcraft`.
-**Note that you also need to add the `serialized_data_interface` dependency to your
-charm's `requirements.txt`.**
 
 ```shell
 charmcraft fetch-lib charms.traefik_k8s.v0.ingress_per_unit
@@ -49,7 +47,7 @@ class SomeCharm(CharmBase):
 ```
 """
 import logging
-from typing import Dict, Optional, Tuple, TypeVar, Union
+from typing import Dict, Optional, TypeVar, Union
 
 import ops.model
 import yaml
@@ -73,7 +71,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 log = logging.getLogger(__name__)
 
@@ -114,15 +112,15 @@ INGRESS_PROVIDES_APP_SCHEMA = {
                 "": {
                     "type": "object",
                     "properties": {
-                        # Optional key for backwards compatibility
-                        # with legacy requirers based on SDI
-                        "_supported_versions": {"type": "string"},
                         "url": {"type": "string"},
                     },
                     "required": ["url"],
                 }
             },
-        }
+        },
+        # Optional key for backwards compatibility
+        # with legacy requirers based on SDI
+        "_supported_versions": {"type": "string"},
     },
     "required": ["ingress"],
 }
@@ -376,7 +374,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
             return False
 
         try:
-            _, requirer_unit_data = self._fetch_relation_data(relation)
+            requirer_unit_data = self._requirer_unit_data(relation)
         except Exception:
             log.exception("Cannot fetch ingress data for the '{}' relation".format(relation))
             return False
@@ -402,7 +400,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
         try:
             # grab the data and validate it; might raise
-            _, requirer_unit_data = self._fetch_relation_data(relation)
+            requirer_unit_data = self._requirer_unit_data(relation)
         except DataValidationError as e:
             log.warning("Failed to validate relation data for {} relation: {}".format(relation, e))
             return True
@@ -485,36 +483,15 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         """
         relation.data[self.app]["data"] = ""
 
-    def _fetch_relation_data(
-        self, relation: Relation
-    ) -> Tuple[ProviderApplicationData, RequirerUnitData]:
-        """Fetch and validate the databags.
-
-        For the provider side: the application databag.
-        For the requirer side: the unit databag.
-        """
-        this_unit = self.unit
-        this_app = self.app
-
+    def _requirer_unit_data(self, relation: Relation) -> RequirerUnitData:
+        """Fetch and validate the requirer's unit databag."""
         if not relation.app or not relation.app.name:
             # Handle edge case where remote app name can be missing, e.g.,
             # relation_broken events.
             # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
-            return {}, {}
+            return {}
 
-        provider_app_data = {}
-        # we start by looking at the provider's app databag
-        if this_unit.is_leader():
-            # only leaders can read their app's data
-            data = relation.data[this_app].get("data")
-            deserialized = {}
-            if data:
-                deserialized = yaml.safe_load(data)
-                _validate_data(deserialized, INGRESS_PROVIDES_APP_SCHEMA)
-            provider_app_data = deserialized.get("ingress", {})
-
-        # then look at the requirer's (thus remote) unit databags
-        remote_units = [unit for unit in relation.units if unit.app is not this_app]
+        remote_units = [unit for unit in relation.units if unit.app is not self.app]
 
         requirer_unit_data = {}
         for remote_unit in remote_units:
@@ -524,8 +501,28 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
                 remote_deserialized = yaml.safe_load(remote_data)
                 _validate_data(remote_deserialized, INGRESS_REQUIRES_UNIT_SCHEMA)
             requirer_unit_data[remote_unit] = remote_deserialized
+        return requirer_unit_data
 
-        return provider_app_data, requirer_unit_data
+    def _provider_app_data(self, relation: Relation) -> ProviderApplicationData:
+        """Fetch and validate the provider's app databag."""
+        if not relation.app or not relation.app.name:
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return {}
+
+        provider_app_data = {}
+        # we start by looking at the provider's app databag
+        if self.unit.is_leader():
+            # only leaders can read their app's data
+            data = relation.data[self.app].get("data")
+            deserialized = {}
+            if data:
+                deserialized = yaml.safe_load(data)
+                _validate_data(deserialized, INGRESS_PROVIDES_APP_SCHEMA)
+            provider_app_data = deserialized.get("ingress", {})
+
+        return provider_app_data
 
     @property
     def proxied_endpoints(self) -> dict:
@@ -550,7 +547,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         results = {}
 
         for ingress_relation in self.relations:
-            provider_app_data, _ = self._fetch_relation_data(ingress_relation)
+            provider_app_data = self._provider_app_data(ingress_relation)
             results.update(provider_app_data)
 
         return results

--- a/tests/integration/log-proxy-tester/lib/charms/observability_libs/v0/juju_topology.py
+++ b/tests/integration/log-proxy-tester/lib/charms/observability_libs/v0/juju_topology.py
@@ -1,0 +1,288 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""## Overview.
+
+This document explains how to use the `JujuTopology` class to
+create and consume topology information from Juju in a consistent manner.
+
+The goal of the Juju topology is to uniquely identify a piece
+of software running across any of your Juju-managed deployments.
+This is achieved by combining the following four elements:
+
+- Model name
+- Model UUID
+- Application name
+- Unit identifier
+
+
+For a more in-depth description of the concept, as well as a
+walk-through of it's use-case in observability, see
+[this blog post](https://juju.is/blog/model-driven-observability-part-2-juju-topology-metrics)
+on the Juju blog.
+
+## Library Usage
+
+This library may be used to create and consume `JujuTopology` objects.
+The `JujuTopology` class provides three ways to create instances:
+
+### Using the `from_charm` method
+
+Enables instantiation by supplying the charm as an argument. When
+creating topology objects for the current charm, this is the recommended
+approach.
+
+```python
+topology = JujuTopology.from_charm(self)
+```
+
+### Using the `from_dict` method
+
+Allows for instantion using a dictionary of relation data, like the
+`scrape_metadata` from Prometheus or the labels of an alert rule. When
+creating topology objects for remote charms, this is the recommended
+approach.
+
+```python
+scrape_metadata = json.loads(relation.data[relation.app].get("scrape_metadata", "{}"))
+topology = JujuTopology.from_dict(scrape_metadata)
+```
+
+### Using the class constructor
+
+Enables instantiation using whatever values you want. While this
+is useful in some very specific cases, this is almost certainly not
+what you are looking for as setting these values manually may
+result in observability metrics which do not uniquely identify a
+charm in order to provide accurate usage reporting, alerting,
+horizontal scaling, or other use cases.
+
+```python
+topology = JujuTopology(
+    model="some-juju-model",
+    model_uuid="00000000-0000-0000-0000-000000000001",
+    application="fancy-juju-application",
+    unit="fancy-juju-application/0",
+    charm_name="fancy-juju-application-k8s",
+)
+```
+
+"""
+
+import re
+from collections import OrderedDict
+from typing import Dict, List, Optional
+
+# The unique Charmhub library identifier, never change it
+LIBID = "bced1658f20f49d28b88f61f83c2d232"
+
+LIBAPI = 0
+LIBPATCH = 1
+
+
+class InvalidUUIDError(Exception):
+    """Invalid UUID was provided."""
+
+    def __init__(self, uuid: str):
+        self.message = "'{}' is not a valid UUID.".format(uuid)
+        super().__init__(self.message)
+
+
+class JujuTopology:
+    """JujuTopology is used for storing, generating and formatting juju topology information."""
+
+    def __init__(
+        self,
+        model: str,
+        model_uuid: str,
+        application: str,
+        unit: str = None,
+        charm_name: str = None,
+    ):
+        """Build a JujuTopology object.
+
+        A `JujuTopology` object is used for storing and transforming
+        Juju topology information. This information is used to
+        annotate Prometheus scrape jobs and alert rules. Such
+        annotation when applied to scrape jobs helps in identifying
+        the source of the scrapped metrics. On the other hand when
+        applied to alert rules topology information ensures that
+        evaluation of alert expressions is restricted to the source
+        (charm) from which the alert rules were obtained.
+
+        Args:
+            model: a string name of the Juju model
+            model_uuid: a globally unique string identifier for the Juju model
+            application: an application name as a string
+            unit: a unit name as a string
+            charm_name: name of charm as a string
+        """
+        if not self.is_valid_uuid(model_uuid):
+            raise InvalidUUIDError(model_uuid)
+
+        self._model = model
+        self._model_uuid = model_uuid
+        self._application = application
+        self._charm_name = charm_name
+        self._unit = unit
+
+    def is_valid_uuid(self, uuid):
+        """Validates the supplied UUID against the Juju Model UUID pattern."""
+        regex = re.compile(
+            "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
+        )
+        return bool(regex.match(uuid))
+
+    @classmethod
+    def from_charm(cls, charm):
+        """Creates a JujuTopology instance by using the model data available on a charm object.
+
+        Args:
+            charm: a `CharmBase` object for which the `JujuTopology` will be constructed
+        Returns:
+            a `JujuTopology` object.
+        """
+        return cls(
+            model=charm.model.name,
+            model_uuid=charm.model.uuid,
+            application=charm.model.app.name,
+            unit=charm.model.unit.name,
+            charm_name=charm.meta.name,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Factory method for creating `JujuTopology` children from a dictionary.
+
+        Args:
+            data: a dictionary with five keys providing topology information. The keys are
+                - "model"
+                - "model_uuid"
+                - "application"
+                - "unit"
+                - "charm_name"
+                `unit` and `charm_name` may be empty, but will result in more limited
+                labels. However, this allows us to support charms without workloads.
+
+        Returns:
+            a `JujuTopology` object.
+        """
+        return cls(
+            model=data["model"],
+            model_uuid=data["model_uuid"],
+            application=data["application"],
+            unit=data.get("unit", ""),
+            charm_name=data.get("charm_name", ""),
+        )
+
+    def as_dict(
+        self, *, remapped_keys: Dict[str, str] = None, excluded_keys: List[str] = None
+    ) -> OrderedDict:
+        """Format the topology information into an ordered dict.
+
+        Keeping the dictionary ordered is important to be able to
+        compare dicts without having to resort to deep comparisons.
+
+        Args:
+            remapped_keys: A dictionary mapping old key names to new key names,
+                which will be substituted when invoked.
+            excluded_keys: A list of key names to exclude from the returned dict.
+            uuid_length: The length to crop the UUID to.
+        """
+        ret = OrderedDict(
+            [
+                ("model", self.model),
+                ("model_uuid", self.model_uuid),
+                ("application", self.application),
+                ("unit", self.unit),
+                ("charm_name", self.charm_name),
+            ]
+        )
+        if excluded_keys:
+            ret = OrderedDict({k: v for k, v in ret.items() if k not in excluded_keys})
+
+        if remapped_keys:
+            ret = OrderedDict(
+                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v) for k, v in ret.items()  # type: ignore
+            )
+
+        return ret
+
+    @property
+    def identifier(self) -> str:
+        """Format the topology information into a terse string.
+
+        This crops the model UUID, making it unsuitable for comparisons against
+        anything but other identifiers. Mainly to be used as a display name or file
+        name where long strings might become an issue.
+
+        >>> JujuTopology( \
+              model = "a-model", \
+              model_uuid = "00000000-0000-4000-8000-000000000000", \
+              application = "some-app", \
+              unit = "some-app/1" \
+            ).identifier
+        'a-model_00000000_some-app'
+        """
+        parts = self.as_dict(
+            excluded_keys=["unit", "charm_name"],
+        )
+
+        parts["model_uuid"] = self.model_uuid_short
+        values = parts.values()
+
+        return "_".join([str(val) for val in values]).replace("/", "_")
+
+    @property
+    def label_matcher_dict(self) -> Dict[str, str]:
+        """Format the topology information into a dict with keys having 'juju_' as prefix.
+
+        Relabelled topology never includes the unit as it would then only match
+        the leader unit (ie. the unit that produced the dict).
+        """
+        items = self.as_dict(
+            remapped_keys={"charm_name": "charm"},
+            excluded_keys=["unit"],
+        ).items()
+
+        return {"juju_{}".format(key): value for key, value in items if value}
+
+    @property
+    def label_matchers(self) -> str:
+        """Format the topology information into a promql/logql label matcher string.
+
+        Topology label matchers should never include the unit as it
+        would then only match the leader unit (ie. the unit that
+        produced the matchers).
+        """
+        items = self.label_matcher_dict.items()
+        return ", ".join(['{}="{}"'.format(key, value) for key, value in items if value])
+
+    @property
+    def model(self) -> str:
+        """Getter for the juju model value."""
+        return self._model
+
+    @property
+    def model_uuid(self) -> str:
+        """Getter for the juju model uuid value."""
+        return self._model_uuid
+
+    @property
+    def model_uuid_short(self) -> str:
+        """Getter for the juju model value, truncated to the first eight letters."""
+        return self._model_uuid[:8]
+
+    @property
+    def application(self) -> str:
+        """Getter for the juju application value."""
+        return self._application
+
+    @property
+    def charm_name(self) -> Optional[str]:
+        """Getter for the juju charm name value."""
+        return self._charm_name
+
+    @property
+    def unit(self) -> Optional[str]:
+        """Getter for the juju unit value."""
+        return self._unit

--- a/tests/integration/loki-tester/lib/charms/observability_libs/v0/juju_topology.py
+++ b/tests/integration/loki-tester/lib/charms/observability_libs/v0/juju_topology.py
@@ -1,0 +1,288 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""## Overview.
+
+This document explains how to use the `JujuTopology` class to
+create and consume topology information from Juju in a consistent manner.
+
+The goal of the Juju topology is to uniquely identify a piece
+of software running across any of your Juju-managed deployments.
+This is achieved by combining the following four elements:
+
+- Model name
+- Model UUID
+- Application name
+- Unit identifier
+
+
+For a more in-depth description of the concept, as well as a
+walk-through of it's use-case in observability, see
+[this blog post](https://juju.is/blog/model-driven-observability-part-2-juju-topology-metrics)
+on the Juju blog.
+
+## Library Usage
+
+This library may be used to create and consume `JujuTopology` objects.
+The `JujuTopology` class provides three ways to create instances:
+
+### Using the `from_charm` method
+
+Enables instantiation by supplying the charm as an argument. When
+creating topology objects for the current charm, this is the recommended
+approach.
+
+```python
+topology = JujuTopology.from_charm(self)
+```
+
+### Using the `from_dict` method
+
+Allows for instantion using a dictionary of relation data, like the
+`scrape_metadata` from Prometheus or the labels of an alert rule. When
+creating topology objects for remote charms, this is the recommended
+approach.
+
+```python
+scrape_metadata = json.loads(relation.data[relation.app].get("scrape_metadata", "{}"))
+topology = JujuTopology.from_dict(scrape_metadata)
+```
+
+### Using the class constructor
+
+Enables instantiation using whatever values you want. While this
+is useful in some very specific cases, this is almost certainly not
+what you are looking for as setting these values manually may
+result in observability metrics which do not uniquely identify a
+charm in order to provide accurate usage reporting, alerting,
+horizontal scaling, or other use cases.
+
+```python
+topology = JujuTopology(
+    model="some-juju-model",
+    model_uuid="00000000-0000-0000-0000-000000000001",
+    application="fancy-juju-application",
+    unit="fancy-juju-application/0",
+    charm_name="fancy-juju-application-k8s",
+)
+```
+
+"""
+
+import re
+from collections import OrderedDict
+from typing import Dict, List, Optional
+
+# The unique Charmhub library identifier, never change it
+LIBID = "bced1658f20f49d28b88f61f83c2d232"
+
+LIBAPI = 0
+LIBPATCH = 1
+
+
+class InvalidUUIDError(Exception):
+    """Invalid UUID was provided."""
+
+    def __init__(self, uuid: str):
+        self.message = "'{}' is not a valid UUID.".format(uuid)
+        super().__init__(self.message)
+
+
+class JujuTopology:
+    """JujuTopology is used for storing, generating and formatting juju topology information."""
+
+    def __init__(
+        self,
+        model: str,
+        model_uuid: str,
+        application: str,
+        unit: str = None,
+        charm_name: str = None,
+    ):
+        """Build a JujuTopology object.
+
+        A `JujuTopology` object is used for storing and transforming
+        Juju topology information. This information is used to
+        annotate Prometheus scrape jobs and alert rules. Such
+        annotation when applied to scrape jobs helps in identifying
+        the source of the scrapped metrics. On the other hand when
+        applied to alert rules topology information ensures that
+        evaluation of alert expressions is restricted to the source
+        (charm) from which the alert rules were obtained.
+
+        Args:
+            model: a string name of the Juju model
+            model_uuid: a globally unique string identifier for the Juju model
+            application: an application name as a string
+            unit: a unit name as a string
+            charm_name: name of charm as a string
+        """
+        if not self.is_valid_uuid(model_uuid):
+            raise InvalidUUIDError(model_uuid)
+
+        self._model = model
+        self._model_uuid = model_uuid
+        self._application = application
+        self._charm_name = charm_name
+        self._unit = unit
+
+    def is_valid_uuid(self, uuid):
+        """Validates the supplied UUID against the Juju Model UUID pattern."""
+        regex = re.compile(
+            "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
+        )
+        return bool(regex.match(uuid))
+
+    @classmethod
+    def from_charm(cls, charm):
+        """Creates a JujuTopology instance by using the model data available on a charm object.
+
+        Args:
+            charm: a `CharmBase` object for which the `JujuTopology` will be constructed
+        Returns:
+            a `JujuTopology` object.
+        """
+        return cls(
+            model=charm.model.name,
+            model_uuid=charm.model.uuid,
+            application=charm.model.app.name,
+            unit=charm.model.unit.name,
+            charm_name=charm.meta.name,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Factory method for creating `JujuTopology` children from a dictionary.
+
+        Args:
+            data: a dictionary with five keys providing topology information. The keys are
+                - "model"
+                - "model_uuid"
+                - "application"
+                - "unit"
+                - "charm_name"
+                `unit` and `charm_name` may be empty, but will result in more limited
+                labels. However, this allows us to support charms without workloads.
+
+        Returns:
+            a `JujuTopology` object.
+        """
+        return cls(
+            model=data["model"],
+            model_uuid=data["model_uuid"],
+            application=data["application"],
+            unit=data.get("unit", ""),
+            charm_name=data.get("charm_name", ""),
+        )
+
+    def as_dict(
+        self, *, remapped_keys: Dict[str, str] = None, excluded_keys: List[str] = None
+    ) -> OrderedDict:
+        """Format the topology information into an ordered dict.
+
+        Keeping the dictionary ordered is important to be able to
+        compare dicts without having to resort to deep comparisons.
+
+        Args:
+            remapped_keys: A dictionary mapping old key names to new key names,
+                which will be substituted when invoked.
+            excluded_keys: A list of key names to exclude from the returned dict.
+            uuid_length: The length to crop the UUID to.
+        """
+        ret = OrderedDict(
+            [
+                ("model", self.model),
+                ("model_uuid", self.model_uuid),
+                ("application", self.application),
+                ("unit", self.unit),
+                ("charm_name", self.charm_name),
+            ]
+        )
+        if excluded_keys:
+            ret = OrderedDict({k: v for k, v in ret.items() if k not in excluded_keys})
+
+        if remapped_keys:
+            ret = OrderedDict(
+                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v) for k, v in ret.items()  # type: ignore
+            )
+
+        return ret
+
+    @property
+    def identifier(self) -> str:
+        """Format the topology information into a terse string.
+
+        This crops the model UUID, making it unsuitable for comparisons against
+        anything but other identifiers. Mainly to be used as a display name or file
+        name where long strings might become an issue.
+
+        >>> JujuTopology( \
+              model = "a-model", \
+              model_uuid = "00000000-0000-4000-8000-000000000000", \
+              application = "some-app", \
+              unit = "some-app/1" \
+            ).identifier
+        'a-model_00000000_some-app'
+        """
+        parts = self.as_dict(
+            excluded_keys=["unit", "charm_name"],
+        )
+
+        parts["model_uuid"] = self.model_uuid_short
+        values = parts.values()
+
+        return "_".join([str(val) for val in values]).replace("/", "_")
+
+    @property
+    def label_matcher_dict(self) -> Dict[str, str]:
+        """Format the topology information into a dict with keys having 'juju_' as prefix.
+
+        Relabelled topology never includes the unit as it would then only match
+        the leader unit (ie. the unit that produced the dict).
+        """
+        items = self.as_dict(
+            remapped_keys={"charm_name": "charm"},
+            excluded_keys=["unit"],
+        ).items()
+
+        return {"juju_{}".format(key): value for key, value in items if value}
+
+    @property
+    def label_matchers(self) -> str:
+        """Format the topology information into a promql/logql label matcher string.
+
+        Topology label matchers should never include the unit as it
+        would then only match the leader unit (ie. the unit that
+        produced the matchers).
+        """
+        items = self.label_matcher_dict.items()
+        return ", ".join(['{}="{}"'.format(key, value) for key, value in items if value])
+
+    @property
+    def model(self) -> str:
+        """Getter for the juju model value."""
+        return self._model
+
+    @property
+    def model_uuid(self) -> str:
+        """Getter for the juju model uuid value."""
+        return self._model_uuid
+
+    @property
+    def model_uuid_short(self) -> str:
+        """Getter for the juju model value, truncated to the first eight letters."""
+        return self._model_uuid[:8]
+
+    @property
+    def application(self) -> str:
+        """Getter for the juju application value."""
+        return self._application
+
+    @property
+    def charm_name(self) -> Optional[str]:
+        """Getter for the juju charm name value."""
+        return self._charm_name
+
+    @property
+    def unit(self) -> Optional[str]:
+        """Getter for the juju unit value."""
+        return self._unit

--- a/tests/integration/loki-tester/src/charm.py
+++ b/tests/integration/loki-tester/src/charm.py
@@ -8,7 +8,8 @@ import logging
 from multiprocessing import Queue
 
 import logging_loki  # type: ignore
-from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer, ProviderTopology
+from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
+from charms.observability_libs.v0.juju_topology import JujuTopology
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus
@@ -34,7 +35,7 @@ class LokiTesterCharm(CharmBase):
             self._on_loki_push_api_endpoint_departed,
         )
 
-        self.topology = ProviderTopology.from_charm(self)
+        self.topology = JujuTopology.from_charm(self)
         self.unit.status = ActiveStatus()
 
     def _setup_logging(self, handlers_init: dict = None) -> None:
@@ -139,7 +140,7 @@ class LokiTesterCharm(CharmBase):
             self._setup_logging({})
             return
 
-        tags = self.topology.as_promql_label_dict()
+        tags = self.topology.label_matcher_dict
         log_endpoints = self._loki_consumer.loki_endpoints
 
         loki_handlers = {}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -22,7 +22,7 @@ ops.testing.SIMULATE_CAN_CONNECT = True
 
 METADATA = {
     "model": "consumer-model",
-    "model_uuid": "qwerty-1234",
+    "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
     "application": "promtail",
     "charm_name": "charm-k8s",
 }
@@ -453,13 +453,9 @@ class TestAppRelationData(unittest.TestCase):
         self.assertTrue(url.startswith("http"))
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestAlertRuleBlockedStatus(unittest.TestCase):
     """Ensure that Loki 'keeps' BlockedStatus from alert rules until another rules event."""
 
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def setUp(self):
         # Patch _check_alert_rules, which attempts to talk to a loki server endpoint

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -453,9 +453,13 @@ class TestAppRelationData(unittest.TestCase):
         self.assertTrue(url.startswith("http"))
 
 
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestAlertRuleBlockedStatus(unittest.TestCase):
     """Ensure that Loki 'keeps' BlockedStatus from alert rules until another rules event."""
 
+    @patch(
+        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
+    )
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def setUp(self):
         # Patch _check_alert_rules, which attempts to talk to a loki server endpoint

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -6,7 +6,6 @@ import os
 import textwrap
 import unittest
 from pathlib import Path
-from unittest.mock import patch
 
 import yaml
 from charms.loki_k8s.v0.loki_push_api import AlertRules, LokiPushApiConsumer
@@ -85,11 +84,7 @@ class FakeConsumerCharm(CharmBase):
         return "10.1.2.3"
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLokiPushApiConsumer(unittest.TestCase):
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     def setUp(self):
         self.harness = Harness(FakeConsumerCharm, meta=FakeConsumerCharm.metadata_yaml)
         self.addCleanup(self.harness.cleanup)
@@ -177,7 +172,6 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         self.assertEqual(self.harness.charm._stored.endpoint_events, 2)
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestReloadAlertRules(unittest.TestCase):
     """Feature: Consumer charm can manually invoke reloading of alerts.
 
@@ -191,9 +185,6 @@ class TestReloadAlertRules(unittest.TestCase):
     # use a short-form free-standing alert, for brevity
     ALERT = yaml.safe_dump({"alert": "free_standing", "expr": "avg(some_vector[5m]) > 5"})
 
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     def setUp(self):
         # override the default ordering, since each of these steps depends on the
         # state of the previous test
@@ -311,7 +302,6 @@ class TestReloadAlertRules(unittest.TestCase):
         self.assertEqual(relation.data[self.harness.charm.app].get("alert_rules"), self.NO_ALERTS)
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestAlertRuleNaming(unittest.TestCase):
     """AlertRules should return sanitized names for any given relative path.
 
@@ -321,18 +311,18 @@ class TestAlertRuleNaming(unittest.TestCase):
     """
 
     PATHS = {
-        r"src/alert_rules/foo.rule": "testing_1234-567_tester_render_alerts",
-        r"src/alert_rules/a/foo.rule": "testing_1234-567_tester_a_render_alerts",
-        r"src/alert_rules/a/b/foo.rule": "testing_1234-567_tester_a_b_render_alerts",
-        r"src/alert_rules/../../proc/cpuinfo": "testing_1234-567_tester_proc_render_alerts",
-        r"src/alert_rules/../../../sys/class/net": "testing_1234-567_tester_sys_class_render_alerts",
+        r"src/alert_rules/foo.rule": "testing_20ce8299_tester_render_alerts",
+        r"src/alert_rules/a/foo.rule": "testing_20ce8299_tester_a_render_alerts",
+        r"src/alert_rules/a/b/foo.rule": "testing_20ce8299_tester_a_b_render_alerts",
+        r"src/alert_rules/../../proc/cpuinfo": "testing_20ce8299_tester_proc_render_alerts",
+        r"src/alert_rules/../../../sys/class/net": "testing_20ce8299_tester_sys_class_render_alerts",
     }
 
     def test_path_transformation(self):
         topology = JujuTopology.from_dict(
             {
                 "model": "testing",
-                "model_uuid": "1234-5678-dead-beef",
+                "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
                 "application": "tester",
                 "unit": "tester/0",
             }
@@ -345,7 +335,6 @@ class TestAlertRuleNaming(unittest.TestCase):
             self.assertEqual(val, rename)
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestAlertRuleFormat(unittest.TestCase):
     """Feature: Consumer lib should warn when encountering invalid rules files.
 
@@ -358,9 +347,6 @@ class TestAlertRuleFormat(unittest.TestCase):
 
     NO_ALERTS = json.dumps({})  # relation data representation for the case of "no alerts"
 
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     def setUp(self):
         self.sandbox = TempFS("consumer_rule_files", auto_clean=True)
         self.addCleanup(self.sandbox.close)
@@ -391,7 +377,7 @@ class TestAlertRuleFormat(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
 
         self.peer_rel_id = self.harness.add_relation("replicas", self.harness.model.app.name)
-        self.harness.set_model_name("dead-beef")
+        self.harness.set_model_name("20ce8299-3634-4bef-8bd8-5ace6c8816b4")
         self.harness.set_leader(True)
 
         self.rel_id = self.harness.add_relation(relation_name="logging", remote_app="loki")

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -140,9 +140,12 @@ class ConsumerCharmWithPromtailResource(CharmBase):
         )
 
 
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLogProxyConsumer(unittest.TestCase):
+    @patch(
+        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
+    )
     def setUp(self):
-
         self.harness = Harness(ConsumerCharm, meta=ConsumerCharm.metadata_yaml)
         self.harness.set_model_info(name="MODEL", uuid="123456")
         self.addCleanup(self.harness.cleanup)
@@ -268,7 +271,11 @@ class TestLogProxyConsumer(unittest.TestCase):
         self.assertEqual(self.harness.charm.log_proxy._current_config, {})
 
 
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLogProxyConsumerWithoutSyslog(unittest.TestCase):
+    @patch(
+        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
+    )
     def setUp(self):
 
         self.harness = Harness(ConsumerCharmSyslogDisabled, meta=ConsumerCharm.metadata_yaml)
@@ -287,9 +294,12 @@ class TestLogProxyConsumerWithoutSyslog(unittest.TestCase):
         )
 
 
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLogProxyConsumerWithPromtailResource(unittest.TestCase):
+    @patch(
+        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
+    )
     def setUp(self):
-
         self.harness = Harness(
             ConsumerCharmWithPromtailResource, meta=ConsumerCharmWithPromtailResource.metadata_yaml
         )

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -35,21 +35,21 @@ CONFIG = {
                 {
                     "targets": ["localhost"],
                     "labels": {
-                        "job": "juju_MODEL_123456_loki-k8s",
+                        "job": "juju_MODEL_20ce829_loki-k8s",
                         "__path__": "/var/log/apache2/access.log",
                     },
                 },
                 {
                     "targets": ["localhost"],
                     "labels": {
-                        "job": "juju_MODEL_123456_loki-k8s",
+                        "job": "juju_MODEL_20ce829_loki-k8s",
                         "__path__": "/var/log/alternatives.log",
                     },
                 },
                 {
                     "targets": ["localhost"],
                     "labels": {
-                        "job": "juju_MODEL_123456_loki-k8s",
+                        "job": "juju_MODEL_20ce829_loki-k8s",
                         "__path__": "/var/log/test.log",
                     },
                 },
@@ -140,14 +140,10 @@ class ConsumerCharmWithPromtailResource(CharmBase):
         )
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLogProxyConsumer(unittest.TestCase):
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     def setUp(self):
         self.harness = Harness(ConsumerCharm, meta=ConsumerCharm.metadata_yaml)
-        self.harness.set_model_info(name="MODEL", uuid="123456")
+        self.harness.set_model_info(name="MODEL", uuid="20ce8299-3634-4bef-8bd8-5ace6c8816b4")
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
@@ -271,15 +267,11 @@ class TestLogProxyConsumer(unittest.TestCase):
         self.assertEqual(self.harness.charm.log_proxy._current_config, {})
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLogProxyConsumerWithoutSyslog(unittest.TestCase):
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     def setUp(self):
 
         self.harness = Harness(ConsumerCharmSyslogDisabled, meta=ConsumerCharm.metadata_yaml)
-        self.harness.set_model_info(name="MODEL", uuid="123456")
+        self.harness.set_model_info(name="MODEL", uuid="20ce8299-3634-4bef-8bd8-5ace6c8816b4")
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin()
@@ -294,16 +286,12 @@ class TestLogProxyConsumerWithoutSyslog(unittest.TestCase):
         )
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLogProxyConsumerWithPromtailResource(unittest.TestCase):
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     def setUp(self):
         self.harness = Harness(
             ConsumerCharmWithPromtailResource, meta=ConsumerCharmWithPromtailResource.metadata_yaml
         )
-        self.harness.set_model_info(name="MODEL", uuid="123456")
+        self.harness.set_model_info(name="MODEL", uuid="20ce8299-3634-4bef-8bd8-5ace6c8816b4")
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -13,7 +13,7 @@ from ops.testing import Harness
 
 METADATA = {
     "model": "consumer-model",
-    "model_uuid": "qwerty-1234",
+    "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
     "application": "promtail",
     "charm_name": "charm-k8s",
 }
@@ -105,11 +105,7 @@ class FakeLokiCharm(CharmBase):
         )
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLokiPushApiProvider(unittest.TestCase):
-    @patch(
-        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
-    )
     def setUp(self):
         self.harness = Harness(FakeLokiCharm, meta=FakeLokiCharm.metadata_yaml)
         self.addCleanup(self.harness.cleanup)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -105,7 +105,11 @@ class FakeLokiCharm(CharmBase):
         )
 
 
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestLokiPushApiProvider(unittest.TestCase):
+    @patch(
+        "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
+    )
     def setUp(self):
         self.harness = Harness(FakeLokiCharm, meta=FakeLokiCharm.metadata_yaml)
         self.addCleanup(self.harness.cleanup)

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -4,7 +4,6 @@
 import subprocess
 import unittest
 from pathlib import PosixPath
-from unittest.mock import patch
 
 from charms.loki_k8s.v0.loki_push_api import CosTool
 from ops.charm import CharmBase
@@ -21,7 +20,6 @@ class ToolProviderCharm(CharmBase):
         self.tool = CosTool(self)
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestTransform(unittest.TestCase):
     """Test that the cos-tool implementation works."""
 
@@ -146,7 +144,6 @@ class TestTransform(unittest.TestCase):
         self.assertTrue(all(['{}="{}"'.format(k, v) in output for k, v in keys.items()]))
 
 
-@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestValidateAlerts(unittest.TestCase):
     """Test that the cos-tool validation works."""
 

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -1,0 +1,201 @@
+# Copyright 2020 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import subprocess
+import unittest
+from pathlib import PosixPath
+from unittest.mock import patch
+
+from charms.loki_k8s.v0.loki_push_api import CosTool
+from ops.charm import CharmBase
+from ops.testing import Harness
+
+
+# noqa: E302
+# pylint: disable=too-few-public-methods
+class ToolProviderCharm(CharmBase):
+    """Container charm for running the integration test."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.tool = CosTool(self)
+
+
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
+class TestTransform(unittest.TestCase):
+    """Test that the cos-tool implementation works."""
+
+    def setUp(self):
+        self.harness = Harness(ToolProviderCharm)
+        self.harness.set_model_name("transform")
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    # pylint: disable=protected-access
+    @unittest.mock.patch("platform.processor", lambda: "teakettle")
+    def test_disable_on_invalid_arch(self):
+        tool = self.harness.charm.tool
+        self.assertIsNone(tool.path)
+        self.assertTrue(tool._disabled)
+
+    # pylint: disable=protected-access
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_gives_path_on_valid_arch(self):
+        """When given a valid arch, it should return the binary path."""
+        transformer = self.harness.charm.tool
+        self.assertIsInstance(transformer.path, PosixPath)
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_setup_transformer(self):
+        """When setup it should know the path to the binary."""
+        tool = self.harness.charm.tool
+
+        self.assertIsInstance(tool.path, PosixPath)
+
+        p = str(tool.path)
+        self.assertTrue(p.endswith("cos-tool-amd64"))
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("subprocess.run")
+    def test_returns_original_expression_when_subprocess_call_errors(self, mocked_run):
+        mocked_run.side_effect = subprocess.CalledProcessError(
+            returncode=10, cmd="cos-tool", stderr=""
+        )
+
+        tool = self.harness.charm.tool
+        output = tool.apply_label_matchers(
+            {
+                "groups": [
+                    {
+                        "alert": "CPUOverUse",
+                        "expr": '{job="foo"} |= "info"',
+                        "for": "0m",
+                        "labels": {
+                            "severity": "Low",
+                            "juju_model": "None",
+                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                            "juju_application": "consumer-tester",
+                        },
+                        "annotations": {
+                            "summary": "Instance {{ $labels.instance }} CPU over use",
+                            "description": "{{ $labels.instance }} of job "
+                            "{{ $labels.job }} has used too much CPU.",
+                        },
+                    }
+                ]
+            }
+        )
+        self.assertEqual(output["groups"][0]["expr"], '{job="foo"} |= "info"')
+
+    @unittest.mock.patch("platform.processor", lambda: "invalid")
+    def test_uses_original_expression_when_binary_missing(self):
+        tool = self.harness.charm.tool
+        output = tool.apply_label_matchers(
+            {
+                "groups": [
+                    {
+                        "alert": "CPUOverUse",
+                        "expr": '{job="foo"} |= "info"',
+                        "for": "0m",
+                        "labels": {
+                            "severity": "Low",
+                            "juju_model": "None",
+                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                            "juju_application": "consumer-tester",
+                        },
+                        "annotations": {
+                            "summary": "Instance {{ $labels.instance }} CPU over use",
+                            "description": "{{ $labels.instance }} of job "
+                            "{{ $labels.job }} has used too much CPU.",
+                        },
+                    }
+                ]
+            }
+        )
+        self.assertEqual(output["groups"][0]["expr"], '{job="foo"} |= "info"')
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_fetches_the_correct_expression(self):
+        tool = self.harness.charm.tool
+
+        output = tool.inject_label_matchers(
+            '{env="production"}', {"juju_model": "some_juju_model"}
+        )
+        assert output == '{env="production", juju_model="some_juju_model"}'
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_handles_comparisons(self):
+        tool = self.harness.charm.tool
+        output = tool.inject_label_matchers(
+            'rate({env="production"} |= "info" [10m]) > 1', {"juju_model": "some_juju_model"}
+        )
+        assert (
+            output == '(rate({env="production", juju_model="some_juju_model"} |= "info"[10m]) > 1)'
+        )
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_handles_multiple_labels(self):
+        tool = self.harness.charm.tool
+        keys = {
+            "juju_model": "some_juju_model",
+            "juju_model_uuid": "123ABC",
+            "juju_application": "some_application",
+            "juju_unit": "some_application/1",
+        }
+        output = tool.inject_label_matchers('{env="production"}', keys)
+        self.assertTrue(all(['{}="{}"'.format(k, v) in output for k, v in keys.items()]))
+
+
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
+class TestValidateAlerts(unittest.TestCase):
+    """Test that the cos-tool validation works."""
+
+    def setUp(self):
+        self.harness = Harness(ToolProviderCharm)
+        self.harness.set_model_name("validate")
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_returns_errors_on_bad_rule_file(self):
+        tool = self.harness.charm.tool
+        valid, errs = tool.validate_alert_rules(
+            {
+                "groups": [
+                    {
+                        "alert": "BadSyntax",
+                        "expr": "rate{) > 0.12",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(valid, False)
+        self.assertIn(errs, "error validating:")
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_successfully_validates_good_alert_rules(self):
+        tool = self.harness.charm.tool
+        valid, errs = tool.validate_alert_rules(
+            {
+                "groups": [
+                    {
+                        "alert": "CPUOverUse",
+                        "expr": 'rate({job="unit_test"} [5m]) > 0.12',
+                        "for": "0m",
+                        "labels": {
+                            "severity": "Low",
+                            "juju_model": "None",
+                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                            "juju_application": "consumer-tester",
+                        },
+                        "annotations": {
+                            "summary": "Instance {{ $labels.instance }} CPU over use",
+                            "description": "{{ $labels.instance }} of job "
+                            "{{ $labels.job }} has used too much CPU.",
+                        },
+                    }
+                ]
+            }
+        )
+        self.assertEqual(errs, "")
+        self.assertEqual(valid, True)

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ deps =
     fs
     -r{toxinidir}/requirements.txt
 commands =
+    /usr/bin/env sh -c 'stat cos-tool-amd64 > /dev/null 2>&1 || curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64'
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \
       -m pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/unit


### PR DESCRIPTION
## Issue
Kind of a lot.

A mechanism was needed to validate alert rules _before_ Loki died if they were loaded, and `JujuTopology` is now in `observability-libs`, so removal of the custom code was slated.


## Solution
Add `cos-tool`, which does what `promql-transform` did for PromQL label tranformation, plus also handlingalert rule validation. Add tests for all of that, and an event fired back if an alert rule is invalid, which is then excluded from being loaded into Prometheus

Replace the "custom" `JujuTopology` with the one from `observability-libs`, which works well, but required a really annoying amount of updates to tests, especially unit tests to avoid `InvalidUUID` exceptions blowing them up.

## Testing Instructions
Test, run, be joyful.

## Release Notes
Use `JujuTopology` from observability-libs, validate alert rules, inject label matchers without `%%juju_topology%%`