### PR TITLE
Relabel structured syslog data

### DIFF
--- a/tests/integration/test_log_proxy.py
+++ b/tests/integration/test_log_proxy.py
@@ -106,6 +106,10 @@ async def test_logproxy_syslog_logs(ops_test, log_proxy_tester_charm):
     logs = await loki_api_query(
         ops_test, loki_app_name, f'{{juju_application=~"{tester_app_name}",job=~".+syslog"}}'
     )
+
+    # Default syslog labels and one structured one to remap
+    syslog_labels = ["facility", "hostname", "severity", "timeQuality_syncAccuracy"]
+    assert all([label in logs[0]["stream"] for label in syslog_labels])
     assert len(logs[0]["values"]) > 0
 
 


### PR DESCRIPTION
## Issue
Promtail is able to parse structured syslog data into labels, but those labels are prefixed with underscores and may not be meaningful to users who are attempting to query or integrate them into dashboards.


## Solution
Transform `__syslog_message_foo` and `__syslog_message_sd_{id}_{key}` into more 

## Context
The fixed labels are culled from [here](https://github.com/grafana/loki/blob/b24a1430434770a5c4eddc19bfe8e1eddf498a15/pkg/promtail/targets/syslog/syslogtarget.go#L180)

## Testing Instructions
Run the integration tests, or connect a syslog target.

## Release Notes
Relabel structured syslog data