### PR TITLE
Allow an instance of LogProxyConsumer per container [do not merge: experiment]

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1371,8 +1371,10 @@ class ConsumerBase(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         recursive: bool = False,
+        *,
+        key: Optional[str] = None,
     ):
-        super().__init__(charm, relation_name)
+        super().__init__(charm, key or relation_name)
         self._charm = charm
         self._relation_name = relation_name
         self.topology = JujuTopology.from_charm(charm)
@@ -1685,11 +1687,15 @@ class LogProxyConsumer(ConsumerBase):
         container_name: str = "",
         promtail_resource_name: Optional[str] = None,
     ):
-        super().__init__(charm, relation_name, alert_rules_path, recursive)
         self._charm = charm
         self._relation_name = relation_name
         self._container = self._get_container(container_name)
         self._container_name = self._get_container_name(container_name)
+
+        key = "{}_{}".format(relation_name, self._container_name)
+        logger.info("KEY %s", key)
+        super().__init__(charm, relation_name, alert_rules_path, recursive, key=key)
+
         self._log_files = log_files or []
         self._syslog_port = syslog_port
         self._is_syslog = enable_syslog

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -75,6 +75,8 @@ class ConsumerCharm(CharmBase):
         containers:
           loki:
             resource: loki-image
+          loki2:
+            resource: loki-image
           promtail:
             resource: promtail-image
         requires:
@@ -90,6 +92,9 @@ class ConsumerCharm(CharmBase):
         self._stored.set_default(invalid_events=0)
         self.log_proxy = LogProxyConsumer(
             charm=self, container_name="loki", log_files=LOG_FILES, enable_syslog=True
+        )
+        self.log_proxy2 = LogProxyConsumer(
+            charm=self, container_name="loki2", log_files=LOG_FILES, enable_syslog=True
         )
 
         self.framework.observe(
@@ -117,6 +122,8 @@ class ConsumerCharmWithPromtailResource(CharmBase):
         containers:
           loki:
             resource: loki-image
+          loki2:
+            resource: loki-image
           promtail:
             resource: promtail-image
         requires:
@@ -137,6 +144,9 @@ class ConsumerCharmWithPromtailResource(CharmBase):
         self._stored.set_default(invalid_events=0)
         self.log_proxy = LogProxyConsumer(
             charm=self, container_name="loki", log_files=LOG_FILES, enable_syslog=True
+        )
+        self.log_proxy2 = LogProxyConsumer(
+            charm=self, container_name="loki2", log_files=LOG_FILES, enable_syslog=True
         )
 
 


### PR DESCRIPTION
## Issue
Currently it is impossible to create multiple instances of LogProxyConsumer for the same relation.

## Solution
Allow an instance per relation per container.

- [x] add `container_name` to the `Object key`.
- [ ] rework relation data schema
- [ ] tests

Addresses #186.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
