### PR TITLE
Fix ingress

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -294,6 +294,8 @@ class LokiOperatorCharm(CharmBase):
         Some minimal configuration is required for Loki to start, including: storage paths, schema,
         ring.
 
+        Reference: https://grafana.com/docs/loki/latest/configuration/
+
         Returns:
             Dictionary representation of the Loki YAML config
         """
@@ -305,6 +307,7 @@ class LokiOperatorCharm(CharmBase):
             server:
               http_listen_port: {self._port}
               http_listen_address: 0.0.0.0
+              http_path_prefix: {urlparse(self._external_url).path}
 
             common:
               path_prefix: {LOKI_DIR}

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,6 @@ commands =
 description = Run integration tests
 deps =
     aiohttp
-    #git+https://github.com/juju/python-libjuju.git
     juju
     pytest
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -92,8 +92,7 @@ description = Run integration tests
 deps =
     aiohttp
     #git+https://github.com/juju/python-libjuju.git
-    #juju
-    juju == 2.9.10
+    juju
     pytest
     pytest-operator
     requests


### PR DESCRIPTION
## Issue
Ingress is not set correctly for loki:
- The loki config file is not use `external_url`.
- After `remove-relation`, the loki ingress is still the traefik address, i.e. it is not being reset.


## Solution
- Observe `ingress_per_unit.on.revoked_for_unit`
- Set `ruler.external_url` in config file


## Context
Load tests.


## Testing Instructions
- Deploy and relate loki and traefik.
- Try to curl `loki/metrics` with/without ingress.


## Release Notes
<!-- A digestable summary of the change in this PR -->
