### PR TITLE
Also update the grafana source configuration when ingress is configured

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -148,6 +148,7 @@ class LokiOperatorCharm(CharmBase):
     def _on_ingress_changed(self, _):
         self._configure()
         self.loki_provider.update_endpoint(url=self._external_url)
+        self.grafana_source_provider.update_source(source_url=self._external_url)
 
     def _on_logging_relation_changed(self, event):
         # If there is a change in logging relation, let's update Loki endpoint


### PR DESCRIPTION
## Issue
Update the grafana source address when ingress is configured, which will change the subpath routing

## Solution
The same as `update_endpoint` for Loki

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
This is already tested in the Grafana repo itself, and testing here would introduce a circular dependency

## Release Notes
Also update the grafana source configuration when ingress is configured