### PR TITLE
Refresh alert rules on pebble ready to account for potential pod churn

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -135,6 +135,7 @@ class LokiOperatorCharm(CharmBase):
         self._configure()
 
     def _on_loki_pebble_ready(self, _):
+        self._ensure_alert_rules_path()
         self._regenerate_alert_rules()
         self._configure()
         version = self._loki_version

--- a/src/charm.py
+++ b/src/charm.py
@@ -135,8 +135,8 @@ class LokiOperatorCharm(CharmBase):
         self._configure()
 
     def _on_loki_pebble_ready(self, _):
-        self._ensure_alert_rules_path()
-        self._regenerate_alert_rules()
+        if self._ensure_alert_rules_path():
+            self._regenerate_alert_rules()
         self._configure()
         version = self._loki_version
         if version is not None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -135,6 +135,7 @@ class LokiOperatorCharm(CharmBase):
         self._configure()
 
     def _on_loki_pebble_ready(self, _):
+        self._regenerate_alert_rules()
         self._configure()
         version = self._loki_version
         if version is not None:


### PR DESCRIPTION
## Issue
In case of a host restart, it's possible that no alert events will actually be fired, as there are no relation changes.

## Solution
Pre-emptively attempt to fetch and generate alert rules `on_loki_pebble_ready`. Even in the case of empty alerts, this is harmless.

## Testing Instructions
Deploy Loki. Relate something with alerts. Reboot the host. Ensure they are still present.

## Release Notes
Refresh alert rules on pebble ready to account for potential pod churn