### PR TITLE
Rename self-monitoring dashboard

### DIFF
--- a/src/grafana_dashboards/metrics-dashboard.json
+++ b/src/grafana_dashboards/metrics-dashboard.json
@@ -61,7 +61,7 @@
       }
     ]
   },
-  "description": "Loki metrics via 2.0",
+  "description": "Loki Operator Overview",
   "editable": true,
   "gnetId": 13407,
   "graphTooltip": 0,
@@ -3759,7 +3759,7 @@
     ]
   },
   "timezone": "",
-  "title": "Loki2.0 Global Metrics",
+  "title": "Loki Operator Overview",
   "uid": "MQHVDmtWk",
   "version": 37
 }


### PR DESCRIPTION
## Issue
Currently, the Loki Dashboard is named "Loki2.0 Global Metrics", which harmonizes badly with our other dashboards.


## Solution
Rename to "Loki Operator Overview", making it match Prometheus

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
N/A

## Release Notes
<!-- A digestable summary of the change in this PR -->
Rename the built-in Loki dashboard