### PR TITLE
Make loki_push_api machine charm compatible

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1097,7 +1097,6 @@ class LokiPushApiProvider(Object):
         self._relation_name = relation_name
         self._tool = CosTool(self)
         self.port = int(port)
-
         self.scheme = scheme
         self.address = address
         self.path = path

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1098,13 +1098,6 @@ class LokiPushApiProvider(Object):
         self._tool = CosTool(self)
         self.port = int(port)
 
-        # This needs to return none if it does not exist for
-        # compatibility with machine charms. Also, this should
-        # be removed in v1 of the library as we should not
-        # assume any charm attributes exist except those
-        # guaranteed by ops.
-        self.container = getattr(self._charm, "_container", None)
-
         self.scheme = scheme
         self.address = address
         self.path = path

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1101,7 +1101,7 @@ class LokiPushApiProvider(Object):
         # This needs to return none if it does not exist for
         # compatibility with machine charms. Also, this should
         # be removed in v1 of the library as we should not
-        # assume any charm attributes exist except those 
+        # assume any charm attributes exist except those
         # guaranteed by ops.
         self.container = getattr(self._charm, "_container")
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -484,7 +484,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 logger = logging.getLogger(__name__)
 
@@ -1097,7 +1097,14 @@ class LokiPushApiProvider(Object):
         self._relation_name = relation_name
         self._tool = CosTool(self)
         self.port = int(port)
-        self.container = self._charm._container
+
+        # This needs to return none if it does not exist for
+        # compatibility with machine charms. Also, this should
+        # be removed in v1 of the library as we should not
+        # assume any charm attributes exist except those 
+        # guaranteed by ops.
+        self.container = getattr(self._charm, "_container")
+
         self.scheme = scheme
         self.address = address
         self.path = path

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1103,7 +1103,7 @@ class LokiPushApiProvider(Object):
         # be removed in v1 of the library as we should not
         # assume any charm attributes exist except those
         # guaranteed by ops.
-        self.container = getattr(self._charm, "_container")
+        self.container = getattr(self._charm, "_container", None)
 
         self.scheme = scheme
         self.address = address

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ namespace_packages = true
 explicit_package_bases = true
 check_untyped_defs = true
 allow_redefinition = true
+no_implicit_optional = false
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## Issue
LokiPushApiProvider has an attribute `.container` which is k8s specific.


## Solution
Default the attribute to None.


## Context
It looks like Loki and Grafana Agent both do not use this attribute. Perhaps it would be safe to just remove it?


## Testing Instructions
Not really sure as I can't find anything that uses this.


## Release Notes
* Improvements toward making the LokiPushApiProvider machine charm compatible.
