### PR TITLE
catch ChangeError when restating the container

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -288,7 +288,7 @@ class LokiOperatorCharm(CharmBase):
                 self._container.restart(self._name)
                 logger.info("Loki (re)started")
             except ChangeError as e:
-                msg = str(e)
+                msg = f"Failed to restart loki: {e}"  # or e.err?
                 self.unit.status = BlockedStatus(msg)
                 logger.error(msg)
                 return


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes #219.

## Solution
<!-- A summary of the solution addressing the above issue -->

We added a `try...except` block to catch `ChangeError` in case we try to restart the container while it is being destroyed.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Read #219

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Read #219

## Release Notes
<!-- A digestable summary of the change in this PR -->
