### PR TITLE
Fix the `job=...` expression for alert rules

### DIFF
--- a/.github/workflows/build-promtail-release.yaml
+++ b/.github/workflows/build-promtail-release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.8
+          go-version: 1.18
       - name: Install systemd dependencies
         run: |
           sudo apt-get update
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.8
+          go-version: 1.18
       - name: Build Promtail
         # We run the make-based build with CGO_ENABLED=0
         # because we want statically-linked binaries and

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -766,7 +766,7 @@ class AlertRules:
                         # any string as a "wildcard" which the topology labels will
                         # filter down
                         alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%", r'job=".+"', alert_rule["expr"]),
+                            re.sub(r"%%juju_topology%%", r'job=~".+"', alert_rule["expr"]),
                             self.topology.label_matcher_dict,
                         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
     lib: git+https://github.com/canonical/operator#egg=ops
 commands =
     charm: mypy {[vars]src_path} {posargs}
-    lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    lib: mypy --python-version 3.8 {[vars]lib_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
## Issue
Previously, an explicit matcher (`job=".+"`) was used due to a typo, rather than a fuzzy (`job=~".+"`) matcher. 

Closes #228 
Closes #224

## Solution
Fix the typo.

Also, bump the golang version for promtail releases.

## Release Notes
Fix the `job=...` expression for alert rules