### PR TITLE
Fix TestDelayedPebbleReady pebble-ready issues with ops 2.0.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,4 +70,3 @@ warn_unused_ignores = false
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,4 @@ warn_unused_ignores = false
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -374,7 +374,8 @@ class TestDelayedPebbleReady(unittest.TestCase):
 
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
-        self.harness.begin_with_initial_hooks()
+        self.harness.begin()
+        self.harness.charm.on.config_changed.emit()
 
         # AND a "logging" app joins with several units
         self.log_rel_id = self.harness.add_relation("logging", "consumer-app")


### PR DESCRIPTION
Previously these tests had the following error when trying to use ops 2.0.0rc2:

```
Traceback (most recent call last):
  File "/home/ben/w/loki-k8s-operator/tests/unit/test_charm.py", line 377, in setUp
    self.harness.begin_with_initial_hooks()
  File "/home/ben/w/loki-k8s-operator/.tox/unit/lib/python3.10/site-packages/ops/testing.py", line 353, in begin_with_initial_hooks
    self.container_pebble_ready(container_name)
  ...
NotImplementedError: <bound method _TestingPebbleClient.exec of <ops.testing._TestingPebbleClient object at 0x7f562f1207c0>>
```

It was happening because of the changes to begin_with_initial_hooks() now triggering pebble-ready. Use begin() instead here, and manually emit config-changed so the charm status is set to WaitingStatus.

Also remove the warning about the unexpected asyncio_mode config key in pyproject.toml's pytest configuration.
