### PR TITLE
Type check the `log_files` arg

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 26
+LIBPATCH = 28
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +230,7 @@ RELATION_INTERFACE_NAME = "grafana_dashboard"
 
 TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
     {
-        "allValue": None,
+        "allValue": ".*",
         "datasource": "${prometheusds}",
         "definition": "label_values(up,juju_model)",
         "description": None,
@@ -255,7 +255,7 @@ TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
         "useTags": False,
     },
     {
-        "allValue": None,
+        "allValue": ".*",
         "datasource": "${prometheusds}",
         "definition": 'label_values(up{juju_model=~"$juju_model"},juju_model_uuid)',
         "description": None,
@@ -280,7 +280,7 @@ TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
         "useTags": False,
     },
     {
-        "allValue": None,
+        "allValue": ".*",
         "datasource": "${prometheusds}",
         "definition": 'label_values(up{juju_model=~"$juju_model",juju_model_uuid=~"$juju_model_uuid"},juju_application)',
         "description": None,
@@ -305,7 +305,7 @@ TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
         "useTags": False,
     },
     {
-        "allValue": None,
+        "allValue": ".*",
         "datasource": "${prometheusds}",
         "definition": 'label_values(up{juju_model=~"$juju_model",juju_model_uuid=~"$juju_model_uuid",juju_application=~"$juju_application"},juju_unit)',
         "description": None,
@@ -1691,7 +1691,11 @@ class GrafanaDashboardAggregator(Object):
 
     def remove_dashboards(self, event: RelationBrokenEvent) -> None:
         """Remove a dashboard if the relation is broken."""
-        app_ids = _type_convert_stored(self._stored.id_mappings[event.app.name])  # type: ignore
+        app_ids = _type_convert_stored(self._stored.id_mappings.get(event.app.name, ""))  # type: ignore
+
+        if not app_ids:
+            logger.info("Could not look up stored dashboards for %s", event.app.name)  # type: ignore
+            return
 
         del self._stored.id_mappings[event.app.name]  # type: ignore
         for id in app_ids:
@@ -1731,14 +1735,10 @@ class GrafanaDashboardAggregator(Object):
                 for i in range(len(dash["templating"]["list"])):
                     if (
                         "datasource" in dash["templating"]["list"][i]
-                        and "Juju" in dash["templating"]["list"][i]["datasource"]
+                        and dash["templating"]["list"][i]["datasource"] is not None
                     ):
-                        dash["templating"]["list"][i]["datasource"] = r"${prometheusds}"
-                    if (
-                        "name" in dash["templating"]["list"][i]
-                        and dash["templating"]["list"][i]["name"] == "host"
-                    ):
-                        dash["templating"]["list"][i] = REACTIVE_CONVERTER
+                        if "Juju" in dash["templating"]["list"][i].get("datasource", ""):
+                            dash["templating"]["list"][i]["datasource"] = r"${prometheusds}"
 
                 # Strip out newly-added 'juju_application' template variables which
                 # don't line up with our drop-downs
@@ -1746,7 +1746,7 @@ class GrafanaDashboardAggregator(Object):
                 for i in range(len(dash["templating"]["list"])):
                     if (
                         "name" in dash["templating"]["list"][i]
-                        and dash["templating"]["list"][i]["name"] == "app"
+                        and dash["templating"]["list"][i].get("name", "") == "app"
                     ):
                         del dash_mutable["templating"]["list"][i]
 
@@ -1758,7 +1758,7 @@ class GrafanaDashboardAggregator(Object):
         if "__inputs" in dash:
             inputs = dash
             for i in range(len(dash["__inputs"])):
-                if dash["__inputs"][i]["pluginName"] == "Prometheus":
+                if dash["__inputs"][i].get("pluginName", "") == "Prometheus":
                     del inputs["__inputs"][i]
             if inputs:
                 dash["__inputs"] = inputs["__inputs"]
@@ -1813,13 +1813,22 @@ class GrafanaDashboardAggregator(Object):
             dash = re.sub(r"<< datasource >>", r"${prometheusds}", dash)
             dash = re.sub(r'"datasource": "prom.*?"', r'"datasource": "${prometheusds}"', dash)
             dash = re.sub(
+                r'"datasource": "\$datasource"', r'"datasource": "${prometheusds}"', dash
+            )
+            dash = re.sub(r'"uid": "\$datasource"', r'"uid": "${prometheusds}"', dash)
+            dash = re.sub(
                 r'"datasource": "(!?\w)[\w|\s|-]+?Juju generated.*?"',
                 r'"datasource": "${prometheusds}"',
                 dash,
             )
 
             # Yank out "new"+old LMA topology
-            dash = re.sub(r'(,?juju_application=~)"\$app"', r'\1"\$juju_application"', dash)
+            dash = re.sub(
+                r'(,?\s?juju_application=~)\\"\$app\\"', r'\1\\"$juju_application\\"', dash
+            )
+
+            # Replace old piechart panels
+            dash = re.sub(r'"type": "grafana-piechart-panel"', '"type": "piechart"', dash)
 
             from jinja2 import Template
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -483,7 +483,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 18
 
 logger = logging.getLogger(__name__)
 
@@ -1755,7 +1755,7 @@ class LogProxyConsumer(ConsumerBase):
     def __init__(
         self,
         charm,
-        log_files: Optional[list] = None,
+        log_files: Optional[Union[List[str], str]] = None,
         relation_name: str = DEFAULT_LOG_PROXY_RELATION_NAME,
         enable_syslog: bool = False,
         syslog_port: int = 1514,
@@ -1769,7 +1769,15 @@ class LogProxyConsumer(ConsumerBase):
         self._relation_name = relation_name
         self._container = self._get_container(container_name)
         self._container_name = self._get_container_name(container_name)
-        self._log_files = log_files or []
+
+        if not log_files:
+            log_files = []
+        elif isinstance(log_files, str):
+            log_files = [log_files]
+        else:
+            log_files = list(log_files)
+        self._log_files = log_files
+
         self._syslog_port = syslog_port
         self._is_syslog = enable_syslog
         self.topology = JujuTopology.from_charm(charm)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1774,8 +1774,10 @@ class LogProxyConsumer(ConsumerBase):
             log_files = []
         elif isinstance(log_files, str):
             log_files = [log_files]
-        else:
-            log_files = list(log_files)
+        elif not isinstance(log_files, list) or not all(
+            map(lambda x: isinstance(x, str), log_files)
+        ):
+            raise TypeError("The 'log_files' argument must be a list of strings.")
         self._log_files = log_files
 
         self._syslog_port = syslog_port

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -121,7 +121,7 @@ More complex scrape configurations are possible. For example
             {
                 "targets": ["10.1.32.215:7000", "*:8000"],
                 "labels": {
-                    "some-key": "some-value"
+                    "some_key": "some-value"
                 }
             }
         ]
@@ -151,7 +151,7 @@ each job must be given a unique name:
             {
                 "targets": ["*:7000"],
                 "labels": {
-                    "some-key": "some-value"
+                    "some_key": "some-value"
                 }
             }
         ]
@@ -163,7 +163,7 @@ each job must be given a unique name:
             {
                 "targets": ["*:8000"],
                 "labels": {
-                    "some-other-key": "some-other-value"
+                    "some_other_key": "some-other-value"
                 }
             }
         ]
@@ -368,7 +368,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 32
+LIBPATCH = 33
 
 logger = logging.getLogger(__name__)
 
@@ -686,10 +686,27 @@ class InvalidAlertRuleEvent(EventBase):
         self.errors = snapshot["errors"]
 
 
+class InvalidScrapeJobEvent(EventBase):
+    """Event emitted when alert rule files are not valid."""
+
+    def __init__(self, handle, errors: str = ""):
+        super().__init__(handle)
+        self.errors = errors
+
+    def snapshot(self) -> Dict:
+        """Save error information."""
+        return {"errors": self.errors}
+
+    def restore(self, snapshot):
+        """Restore error information."""
+        self.errors = snapshot["errors"]
+
+
 class MetricsEndpointProviderEvents(ObjectEvents):
     """Events raised by :class:`InvalidAlertRuleEvent`s."""
 
     alert_rule_status_changed = EventSource(InvalidAlertRuleEvent)
+    invalid_scrape_job = EventSource(InvalidScrapeJobEvent)
 
 
 def _type_convert_stored(obj):
@@ -1119,7 +1136,18 @@ class MetricsEndpointConsumer(Object):
         for relation in self._charm.model.relations[self._relation_name]:
             static_scrape_jobs = self._static_scrape_config(relation)
             if static_scrape_jobs:
-                scrape_jobs.extend(static_scrape_jobs)
+                # Duplicate job names will cause validate_scrape_jobs to fail.
+                # Therefore we need to dedupe here and after all jobs are collected.
+                static_scrape_jobs = _dedupe_job_names(static_scrape_jobs)
+                try:
+                    self._tool.validate_scrape_jobs(static_scrape_jobs)
+                except subprocess.CalledProcessError as e:
+                    if self._charm.unit.is_leader():
+                        data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                        data["scrape_job_errors"] = str(e)
+                        relation.data[self._charm.app]["event"] = json.dumps(data)
+                else:
+                    scrape_jobs.extend(static_scrape_jobs)
 
         scrape_jobs = _dedupe_job_names(scrape_jobs)
 
@@ -1198,12 +1226,17 @@ class MetricsEndpointConsumer(Object):
                 )
                 continue
 
+            alerts[identifier] = alert_rules
+
             _, errmsg = self._tool.validate_alert_rules(alert_rules)
             if errmsg:
-                relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
+                if alerts[identifier]:
+                    del alerts[identifier]
+                if self._charm.unit.is_leader():
+                    data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                    data["errors"] = errmsg
+                    relation.data[self._charm.app]["event"] = json.dumps(data)
                 continue
-
-            alerts[identifier] = alert_rules
 
         return alerts
 
@@ -1663,6 +1696,10 @@ class MetricsEndpointProvider(Object):
                     self.on.alert_rule_status_changed.emit(valid=valid)
                 else:
                     self.on.alert_rule_status_changed.emit(valid=valid, errors=errors)
+
+                scrape_errors = ev.get("scrape_job_errors", None)
+                if scrape_errors:
+                    self.on.invalid_scrape_job.emit(errors=scrape_errors)
 
     def update_scrape_job_spec(self, jobs):
         """Update scrape job specification."""
@@ -2472,6 +2509,22 @@ class CosTool:
                         if "error validating" in line
                     ]
                 )
+
+    def validate_scrape_jobs(self, jobs: list) -> bool:
+        """Validate scrape jobs using cos-tool."""
+        if not self.path:
+            logger.debug("`cos-tool` unavailable. Not validating scrape jobs.")
+            return True
+        conf = {"scrape_configs": jobs}
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            with open(tmpfile.name, "w") as f:
+                f.write(yaml.safe_dump(conf))
+            try:
+                self._exec([str(self.path), "validate-config", tmpfile.name])
+            except subprocess.CalledProcessError as e:
+                logger.error("Validating scrape jobs failed: {}".format(e.output))
+                raise
+        return True
 
     def inject_label_matchers(self, expression, topology) -> str:
         """Add label matchers to an expression."""


### PR DESCRIPTION
## Issue
If a user mistakenly passed an str instead of a list for the `log_files` arg, the response is too silent and too late.


## Solution
Raise on type mismatch for `log_files`.

Fixes #226.


## Context
[Temptation](https://typeguard.readthedocs.io/en/latest/) was mild.


## Testing Instructions
Afaict, utest provides sufficient coverage.


## Release Notes
Type check the log_files arg.