### PR TITLE
Switch Loki to use the ROCK on ghcr.io

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -60,5 +60,5 @@ requires:
 resources:
   loki-image:
     type: oci-image
-    description: Loki OCI image "ghcr.io/canonical/loki:latest"
-    upstream-source: ghcr.io/canonical/loki:latest
+    description: Loki OCI image "ghcr.io/canonical/loki:2.7.4"
+    upstream-source: ghcr.io/canonical/loki:2.7.4

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -60,5 +60,5 @@ requires:
 resources:
   loki-image:
     type: oci-image
-    description: Loki OCI image "grafana/loki:2.4.1"
-    upstream-source: grafana/loki:2.4.1
+    description: Loki OCI image "ghcr.io/canonical/loki:latest"
+    upstream-source: ghcr.io/canonical/loki:latest


### PR DESCRIPTION
## Issue
We are currently running Loki using the upstream OCI image.

## Solution
We are now building our own ROCKs for the observability stack. We should also make sure we're using them so that effort is not in vain.

## Testing Instructions
- Deploy the charm with the new resource
- Verify functionality is still there

## Release Notes
Switch from upstream OCI image to ROCK
