### PR TITLE
fix handling of multiple loki_push_api relations

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -484,7 +484,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 logger = logging.getLogger(__name__)
 
@@ -1241,15 +1241,20 @@ class LokiPushApiProvider(Object):
             url: An optional url value to update relation data.
             relation: An optional instance of `class:ops.model.Relation` to update.
         """
+        # if no relation is specified update all of them
         if not relation:
-            if not self._charm.model.get_relation(self._relation_name):
+            if not self._charm.model.relations.get(self._relation_name):
                 return
 
-            relation = self._charm.model.get_relation(self._relation_name)
+            relations_list = self._charm.model.relations.get(self._relation_name)
+        else:
+            relations_list = [relation]
 
         endpoint = self._endpoint(url or self._url)
 
-        relation.data[self._charm.unit].update({"endpoint": json.dumps(endpoint)})
+        for relation in relations_list:
+            relation.data[self._charm.unit].update({"endpoint": json.dumps(endpoint)})
+
         logger.debug("Saved endpoint in unit relation data")
 
     @property


### PR DESCRIPTION
## Issue
Resolves #256.
As suggested in the issue, the `update_endpoint()` function is designed to only handle one relation (see [get_relation() docs](https://ops.readthedocs.io/en/latest/index.html?highlight=get_relation#ops.model.Model.get_relation)).

## Solution
Change `update_endpoint()` to update all relations if a specific one isn't specified.

## Testing Instructions

* pack and deploy Loki from my PR
* deploy some charms that support the `loki_push_api` interface (`traefik:logging` is a good example)
* relate Loki to multiple charms over `loki_push_api`
* relate Loki to Traefik over `ingress` and verify that no ERROR appears in `juju debug-log`

## Release Notes

Change `update_endpoint()` to update all relations if a specific one isn't specified.