### PR TITLE
use ruff instead of flake8

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1077,6 +1077,10 @@ class LokiPushApiProvider(Object):
                 It is strongly advised not to change the default, so that people
                 deploying your charm will have a consistent experience with all
                 other charms that consume metrics endpoints.
+            port: an optional port of the Loki service (default is "3100").
+            scheme: an optional scheme of the Loki API URL (default is "http").
+            address: an optional address of the Loki service (default is "localhost").
+            path: an optional path of the Loki API URL (default is "loki/api/v1/push")
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1546,6 +1550,7 @@ class LokiPushApiConsumer(ConsumerBase):
                 respectively.
             alert_rules_path: a string indicating a path where alert rules can be found
             recursive: Whether or not to scan for rule files recursively.
+            skip_alert_topology_labeling: whether or not to skip the alert topology labeling.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1781,9 +1786,7 @@ class LogProxyConsumer(ConsumerBase):
             log_files = []
         elif isinstance(log_files, str):
             log_files = [log_files]
-        elif not isinstance(log_files, list) or not all(
-            map(lambda x: isinstance(x, str), log_files)
-        ):
+        elif not isinstance(log_files, list) or not all((isinstance(x, str) for x in log_files)):
             raise TypeError("The 'log_files' argument must be a list of strings.")
         self._log_files = log_files
 
@@ -2009,8 +2012,7 @@ class LogProxyConsumer(ConsumerBase):
         except NameError as e:
             if "invalid resource name" in str(e):
                 return False
-            else:
-                raise
+            raise
 
     def _push_promtail_if_attached(self, workload_binary_path: str) -> bool:
         """Checks whether Promtail binary is attached to the charm or not.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,26 +13,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/src/charm.py
+++ b/src/charm.py
@@ -43,12 +43,11 @@ from charms.observability_libs.v1.kubernetes_service_patch import (
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.traefik_k8s.v1.ingress_per_unit import IngressPerUnitRequirer
+from loki_server import LokiServer, LokiServerError, LokiServerNotReadyError
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ChangeError, Error, Layer, PathError, ProtocolError
-
-from loki_server import LokiServer, LokiServerError, LokiServerNotReadyError
 
 # Paths in workload container
 LOKI_CONFIG = "/etc/loki/loki-local-config.yaml"

--- a/src/loki_server.py
+++ b/src/loki_server.py
@@ -55,8 +55,8 @@ class LokiServer:
 
         if response.status_code == requests.codes.ok:
             return response.json()
-        else:
-            response.raise_for_status()
+        response.raise_for_status()
+        return None
 
     @property
     def version(self) -> str:

--- a/tests/integration/test_applications_send_logs.py
+++ b/tests/integration/test_applications_send_logs.py
@@ -148,10 +148,8 @@ async def test_logs_persist_after_upgrade(ops_test, loki_charm):
         # If any of the log counts are higher, we are continuiting. Don't depend on
         # timing the log entries
         assert any(
-            [
-                values_after_upgrade[client][idx] > values_before_upgrade[client][idx]
-                for idx in range(len(values))
-            ]
+            values_after_upgrade[client][idx] > values_before_upgrade[client][idx]
+            for idx in range(len(values))
         )
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,13 +11,12 @@ from urllib.error import HTTPError, URLError
 
 import ops.testing
 import yaml
-from helpers import FakeProcessVersionCheck, k8s_resource_multipatch
-from ops.model import ActiveStatus, BlockedStatus, Container, WaitingStatus
-from ops.testing import Harness
-
 from charm import LOKI_CONFIG as LOKI_CONFIG_PATH
 from charm import LokiOperatorCharm
+from helpers import FakeProcessVersionCheck, k8s_resource_multipatch
 from loki_server import LokiServerError, LokiServerNotReadyError
+from ops.model import ActiveStatus, BlockedStatus, Container, WaitingStatus
+from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -254,7 +254,7 @@ class TestLogProxyConsumer(unittest.TestCase):
 
         with self.assertLogs(level="DEBUG") as logger:
             self.harness.charm.log_proxy._obtain_promtail(PROMTAIL_INFO)
-            self.assertTrue(any(["File sha256sum mismatch" in line for line in logger.output]))
+            self.assertTrue(any("File sha256sum mismatch" in line for line in logger.output))
 
             # Don't actually download, but make sure we would
             self.assertTrue(

--- a/tests/unit/test_loki_server.py
+++ b/tests/unit/test_loki_server.py
@@ -11,7 +11,6 @@ from socketserver import ThreadingMixIn
 from unittest.mock import patch
 
 import requests
-
 from loki_server import LokiServer
 
 

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -141,7 +141,7 @@ class TestTransform(unittest.TestCase):
             "juju_unit": "some_application/1",
         }
         output = tool.inject_label_matchers('{env="production"}', keys)
-        self.assertTrue(all(['{}="{}"'.format(k, v) in output for k, v in keys.items()]))
+        self.assertTrue(all('{}="{}"'.format(k, v) in output for k, v in keys.items()))
 
 
 class TestValidateAlerts(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -31,29 +31,21 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
+    ruff
     codespell
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being one new rule being ignored (which wasn't checked before anyway):
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.