### PR TITLE
Add config options for ingestion rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *~
 *swp
 *.charm

--- a/.jujuignore
+++ b/.jujuignore
@@ -3,3 +3,4 @@
 *.charm
 .#*
 cos-tool*
+/doc

--- a/config.yaml
+++ b/config.yaml
@@ -15,3 +15,25 @@ options:
       automatically deduced from it).
       See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     type: string
+  ingestion-rate-mb:
+    description: |
+      Per-user ingestion rate limit (MB/s).
+      This config option matches exactly Loki's `ingestion_rate_mb`, except that it is an integer here
+      (Loki takes a float).
+      This same value is used internally for setting `per_stream_rate_limit`. Loki uses a default of 3 for
+      `ingestion_rate_mb`, but 4 for `per_stream_rate_limit`. For this reason we use 4 as the default here.
+      
+      Ref: https://grafana.com/docs/loki/latest/configure/#limits_config
+    type: int
+    default: 4
+  ingestion-burst-size-mb:
+    description: |
+      This config option matches exactly Loki's `ingestion_burst_size_mb`, except that it is an integer here
+      (Loki takes a float).
+      This same value is used internally for setting `per_stream_rate_limit_burst`. Loki uses a default of 6 for 
+      `ingestion_burst_size_mb`, but 15 for `per_stream_rate_limit_burst`. For this reason we use 15 as the default
+      here.
+      
+      Ref: https://grafana.com/docs/loki/latest/configure/#limits_config
+    type: int
+    default: 15

--- a/doc/adr/2023-11-21 config options for rate limits.md
+++ b/doc/adr/2023-11-21 config options for rate limits.md
@@ -1,0 +1,48 @@
+# Charm config options for ingestion rate limits
+
+## Context and Problem Statement
+The default ingestion rate limits for Loki result in resource utilization capped at ~30%
+of a 8cpu16gb VM. Juju admins should have a way for configuring the rate limits to allow
+for higher resource utilization.
+
+## Considered Options
+
+- Add individual config options on a per-need basis
+- Config overlay option (deep merge)
+- Juju feature request for nested config options
+
+## Decision Outcome
+
+Chosen option: "Add individual config options on a per-need basis", because we value UX over versatility.
+
+### Consequences
+
+* Good, because config options are easy to use.
+* Good, because involves a maintainable, small volume of changes.
+* Bad, because does not fully address the inherent versatility of Loki config.
+
+## Pros and Cons of the Options
+
+### Add individual config options on a per-need basis
+
+* Good, because config options are easy to use.
+* Good, because involves a maintainable, small volume of changes.
+* Bad, because does not fully address the inherent versatility of Loki config.
+
+### Config overlay option (deep merge)
+
+* Good, because would have a very small code change.
+* Good, because offers the Juju admin the full versatility of Loki config.
+* Bad, because config option would be not as easy to use.
+* Bad, because user-set values may result in undesired overrides of charm options (and 
+  we do not want to manage an exclude-/allow-list).
+
+### Juju feature request for nested config options
+* Good, because we could mirror the entire Loki config as (nested) charm options.
+* Bad, because we would need to maintain a "schema" compatibility with Loki.
+* Bad, because charm revision may become coupled to workload version.
+* Bad, because the feature request is likely to be rejected.
+
+## More Information
+- https://juju.is/docs/sdk/config-yaml#heading--options
+- https://grafana.com/docs/loki/latest/configure/#limits_config

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,37 @@
+ADR template is based on https://adr.github.io/madr/examples.html.
+
+```markdown
+# ADR topic
+
+## Context and Problem Statement
+
+
+## Considered Options
+
+- Option 1
+- Option 2
+
+## Decision Outcome
+
+Chosen option: ..., because ...
+
+### Consequences
+
+* Good, because ...
+* Good, because ...
+* Bad, because ...
+
+## Pros and Cons of the Options
+
+### Option 1
+
+* Good, because ...
+* Bad, because ...
+
+### Option 2
+
+* Good, because ...
+* Bad, because ...
+
+## More Information
+```

--- a/src/charm.py
+++ b/src/charm.py
@@ -309,6 +309,8 @@ class LokiOperatorCharm(CharmBase):
             instance_addr=self.hostname,
             alertmanager_url=self._alerting_config(),
             external_url=self._external_url,
+            ingestion_rate_mb=int(self.config["ingestion-rate-mb"]),
+            ingestion_burst_size_mb=int(self.config["ingestion-burst-size-mb"]),
             http_tls=(self.server_cert.cert is not None),
         ).build()
 


### PR DESCRIPTION
## Issue
The charm does not expose config options for ingestion rate limits.

## Solution
Add config options for ingestion rate limits.

Fixes #323.

## Context
- https://github.com/canonical/cos-lite-bundle/pull/84

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
