### PR TITLE
Modify loki config to address HTTP 429 code (too many reqs)

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -64,6 +64,8 @@ class ConfigBuilder:
             "limits_config": self._limits_config,
             "query_range": self._query_range,
             "chunk_store_config": self._chunk_store_config,
+            "frontend": self._frontend,
+            "querier": self._querier,
         }
 
     @property
@@ -154,6 +156,7 @@ class ConfigBuilder:
     def _query_range(self) -> dict:
         # Ref: https://grafana.com/docs/loki/latest/configure/#query_range
         return {
+            "parallelise_shardable_queries": False,
             "results_cache": {
                 "cache": {
                     "embedded_cache": {
@@ -161,7 +164,7 @@ class ConfigBuilder:
                         "enabled": True
                     }
                 }
-            }
+            },
         }
 
     @property
@@ -174,4 +177,23 @@ class ConfigBuilder:
                     "enabled": True
                 }
             }
+        }
+
+    @property
+    def _frontend(self) -> dict:
+        # Ref: https://grafana.com/docs/loki/latest/configure/#frontend
+        return {
+            # Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.
+            # Default is 2048, but 8cpu16gb can ingest ~3 times more, so set to 4x.
+            "max_outstanding_per_tenant": 8192,
+            # Compress HTTP responses.
+            "compress_responses": True,
+        }
+
+    @property
+    def _querier(self) -> dict:
+        # Ref: https://grafana.com/docs/loki/latest/configure/#querier
+        return {
+            # The maximum number of concurrent queries allowed. Default is 10.
+            "max_concurrent": 20,
         }

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -158,7 +158,7 @@ class ConfigBuilder:
                 "cache": {
                     "embedded_cache": {
                         # https://community.grafana.com/t/too-many-outstanding-requests-on-loki-2-7-1/78249/11
-                        "enabled": "true"
+                        "enabled": True
                     }
                 }
             }
@@ -171,7 +171,7 @@ class ConfigBuilder:
             "chunk_cache_config": {
                 "embedded_cache": {
                     # https://community.grafana.com/t/too-many-outstanding-requests-on-loki-2-7-1/78249/11
-                    "enabled": "true"
+                    "enabled": True
                 }
             }
         }

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -62,6 +62,8 @@ class ConfigBuilder:
             "server": self._server,
             "storage_config": self._storage_config,
             "limits_config": self._limits_config,
+            "query_range": self._query_range,
+            "chunk_store_config": self._chunk_store_config,
         }
 
     @property
@@ -143,4 +145,33 @@ class ConfigBuilder:
             # case of one stream per user.
             "per_stream_rate_limit": f"{self.ingestion_rate_mb}MB",
             "per_stream_rate_limit_burst": f"{self.ingestion_burst_size_mb}MB",
+            # This charmed operator is intended for running a single loki instances, so we don't need to split queries
+            # https://community.grafana.com/t/too-many-outstanding-requests-on-loki-2-7-1/78249/9
+            "split_queries_by_interval": "0",
+        }
+
+    @property
+    def _query_range(self) -> dict:
+        # Ref: https://grafana.com/docs/loki/latest/configure/#query_range
+        return {
+            "results_cache": {
+                "cache": {
+                    "embedded_cache": {
+                        # https://community.grafana.com/t/too-many-outstanding-requests-on-loki-2-7-1/78249/11
+                        "enabled": "true"
+                    }
+                }
+            }
+        }
+
+    @property
+    def _chunk_store_config(self) -> dict:
+        # Ref: https://grafana.com/docs/loki/latest/configure/#chunk_store_config
+        return {
+            "chunk_cache_config": {
+                "embedded_cache": {
+                    # https://community.grafana.com/t/too-many-outstanding-requests-on-loki-2-7-1/78249/11
+                    "enabled": "true"
+                }
+            }
         }


### PR DESCRIPTION
## Issue
Following up on #324, as the problem still persists.

- Getting HTTP codes 429 and others throughout the load test.
- Loki logs `2023-11-22T20:28:31.034Z [loki] level=warn ts=2023-11-22T20:28:30.939304741Z caller=cache.go:114 msg="fifocache config is deprecated. use embedded-cache instead"`

## Solution
- Enable embedded-cache.
- Additional tweaks, per refs inline.

With this change, at high load (`increase(loki_distributor_lines_received_total[1m])` of up to 320,000), all of the following issues are now gone:
- 429 / GET / loki_api_v1_query_range
- 499 / GET / loki_api_v1_query_range
- 500 / GET / loki_api_v1_query_range
- 503 / GET / ready
- 500 / POST / loki_api_v1_push
- cancel / gRPC / /logproto.Querier/Query
- cancel / gRPC / /schedulerpb.SchedulerForQuerier/QuerierLoop

Fixes #283.

## Context
- https://github.com/canonical/cos-lite-bundle/pull/84


## Testing Instructions
```bash
juju refresh --switch loki-k8s --channel=edge/325 loki  # Expires at 2023-12-30T00:00:00Z
```

## Release Notes
<!-- A digestable summary of the change in this PR -->
