### PR TITLE
use cosl for JujuTopology

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -456,7 +456,7 @@ from urllib import request
 from urllib.error import HTTPError
 
 import yaml
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -480,7 +480,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 24
+LIBPATCH = 25
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -450,7 +450,7 @@ from urllib import request
 from urllib.error import HTTPError
 
 import yaml
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -474,7 +474,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cosl
 ops
 kubernetes
 requests

--- a/tests/integration/log-proxy-tester/requirements.txt
+++ b/tests/integration/log-proxy-tester/requirements.txt
@@ -1,1 +1,2 @@
+cosl
 ops @ git+https://github.com/canonical/operator

--- a/tests/integration/loki-tester/requirements.txt
+++ b/tests/integration/loki-tester/requirements.txt
@@ -1,2 +1,3 @@
+cosl
 ops >= 1.2.0
 python-logging-loki

--- a/tests/integration/loki-tester/src/charm.py
+++ b/tests/integration/loki-tester/src/charm.py
@@ -9,7 +9,7 @@ from multiprocessing import Queue
 
 import logging_loki  # type: ignore
 from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import yaml
 from charms.loki_k8s.v0.loki_push_api import AlertRules, LokiPushApiConsumer
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
 from fs.tempfs import TempFS
 from ops.charm import CharmBase
 from ops.framework import StoredState

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    cosl
     aiohttp
     juju
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
+    cosl
     pyright
     charm: -r{toxinidir}/requirements.txt
     lib: git+https://github.com/canonical/operator#egg=ops


### PR DESCRIPTION
## Issue
Closes #310.


## Solution
Import `JujuTopology` from **cosl** instead of using the deprecated `charms.observability_libs.v0.juju_topology`.
