### PR TITLE
Add assumes statement for `juju >= 3.0.3`

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,8 +5,12 @@
 # https://discourse.charmhub.io/t/charm-metadata-v2/3674/15
 
 name: loki-k8s
+
 assumes:
   - k8s-api
+
+  # Juju 3.0.3+ needed for secrets and open-port
+  - juju >= 3.0.3
 
 summary: |
   Loki is a set of components that can be composed into a fully featured logging stack.

--- a/tests/integration/test_alert_rules_are_forwarded.py
+++ b/tests/integration/test_alert_rules_are_forwarded.py
@@ -52,7 +52,7 @@ async def test_alert_rules_do_forward_to_alertmanager(ops_test, loki_charm, loki
             and len(ops_test.model.applications[alertmanager_app_name].units) > 0
         )
     )
-    await ops_test.model.wait_for_idle(apps=app_names, status="active")
+    await ops_test.model.wait_for_idle(apps=app_names, status="active", raise_on_error=False)
 
     await asyncio.gather(
         ops_test.model.add_relation(loki_app_name, tester_app_name),


### PR DESCRIPTION
## Issue
Users are able to deploy on juju 2.9.


## Solution
Add assumes statement for `juju >= 3.0.3`.

