### PR TITLE
Build promtail for arm64

### DIFF
--- a/.github/workflows/build-promtail-release.yaml
+++ b/.github/workflows/build-promtail-release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: [amd64] # [amd64, arm64] # GitHub workflows do not support YAML anchors :-(
+        arch: [amd64, arm64]
     steps:
       - name: Checkout grafana/loki, tag ${{inputs.release}}
         uses: actions/checkout@v2
@@ -58,8 +58,8 @@ jobs:
     # TODO: Also run tests on arm64
     strategy:
       matrix:
-        arch: [amd64] # [amd64, arm64]
-        base: [debian, rh-ubi8, ubuntu]
+        arch: [amd64, arm64]
+        base: [debian, ubuntu]
     steps:
       - name: Checkout ${{github.repository}}
         uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64] # [amd64, arm64] # GitHub workflows do not support YAML anchors :-(
+        arch: [amd64, arm64]
     steps:
       - name: Checkout grafana/loki, tag ${{inputs.release}}
         uses: actions/checkout@v2
@@ -119,10 +119,9 @@ jobs:
     name: Test statically-linked Promtail
     runs-on: ubuntu-latest
     needs: build-static
-    # TODO: Also run tests on arm64
     strategy:
       matrix:
-        arch: [amd64] # [amd64, arm64]
+        arch: [amd64, arm64]
         base: [alpine, debian, rh-ubi8, scratch, ubuntu]
     steps:
       - name: Checkout ${{github.repository}}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
To make `loki_push_api.py` work with arm64, we need to also have a promtail binary built for that arch.

## Solution
<!-- A summary of the solution addressing the above issue -->
Build it! 🔥 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
