### PR TITLE
Only insert labels that do not already exist

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -518,7 +518,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 
@@ -799,7 +799,11 @@ class AlertRules:
                         alert_rule["labels"] = {}
 
                     if self.topology:
-                        alert_rule["labels"].update(self.topology.label_matcher_dict)
+                        # only insert labels that do not already exist
+                        for label, val in self.topology.label_matcher_dict.items():
+                            if label not in alert_rule["labels"]:
+                                alert_rule["labels"][label] = val
+
                         # insert juju topology filters into a prometheus alert rule
                         # logql doesn't like empty matchers, so add a job matcher which hits
                         # any string as a "wildcard" which the topology labels will


### PR DESCRIPTION
## Issue
Alert labels are being overwritten, when they already exist.
This is a problem for deployments with grafana-agent, such as:
```mermaid
graph LR
some-charm ---|logging| grafana-agent ---|logging| loki
```

Before this change, the alert labels of `some-charm` would be set to grafana-agent's topology.

## Solution
Only insert labels that do not already exist. This is exactly what we're [doing in cos-lib](https://github.com/canonical/cos-lib/blob/486945531c3a95253c2ee3886204071b176e7841/src/cosl/rules.py#L298).

(In a different PR, we should refactor loki_push_api to use cos-lib.)

Addresses https://github.com/canonical/grafana-agent-k8s-operator/issues/275.

## Context
This PR is in tandem with:
- https://github.com/canonical/grafana-agent-k8s-operator/pull/277


## Testing Instructions
Deploy this bundle:
```yaml
bundle: kubernetes
applications:
  ga:
    # grafana-agent from https://github.com/canonical/grafana-agent-k8s-operator/pull/277
    # with the modified lib
    charm: ./grafana-agent-k8s_ubuntu-22.04-amd64.charm
    resources:
      agent-image: ubuntu/grafana-agent:0.35.2-22.04_stable
    scale: 1
    trust: true
  loki:
    charm: loki-k8s
    channel: edge
    series: focal
    scale: 1
    trust: true
  trfk:
    charm: traefik-k8s
    channel: edge
    series: focal
    scale: 1
    trust: true
relations:
- - trfk:logging
  - ga:logging-provider
- - ga:logging-consumer
  - loki:logging
```

and make sure `expr` labels and alert labels are correct:
```bash
juju show-unit loki/0 | yq '."loki/0"."relation-info" | .[] | ."application-data".alert_rules' | jq
```

## Upgrade Notes
This change has no impact on Loki itself, but on related charms, so `charmcraft fetch-lib` etc.
