### PR TITLE
Fix keys in the proxies input dict to only be protocol names

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -2119,9 +2119,13 @@ class LogProxyConsumer(ConsumerBase):
         # If no Juju proxy variable was set, we set proxies to None to let the ProxyHandler get
         # the proxy env variables from the environment
         proxies = {
+            # The ProxyHandler uses only the protocol names as keys
+            # https://docs.python.org/3/library/urllib.request.html#urllib.request.ProxyHandler
             "https": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
             "http": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
-            "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+            # The ProxyHandler uses `no` for the no_proxy key
+            # https://github.com/python/cpython/blob/3.12/Lib/urllib/request.py#L2553
+            "no": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
         }
         proxies = {k: v for k, v in proxies.items() if v != ""} or None
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -2119,8 +2119,8 @@ class LogProxyConsumer(ConsumerBase):
         # If no Juju proxy variable was set, we set proxies to None to let the ProxyHandler get
         # the proxy env variables from the environment
         proxies = {
-            "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
-            "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            "https": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+            "http": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
             "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
         }
         proxies = {k: v for k, v in proxies.items() if v != ""} or None

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -480,7 +480,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 27
+LIBPATCH = 28
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -2097,9 +2097,13 @@ class LogProxyConsumer(ConsumerBase):
         # If no Juju proxy variable was set, we set proxies to None to let the ProxyHandler get
         # the proxy env variables from the environment
         proxies = {
+            # The ProxyHandler uses only the protocol names as keys
+            # https://docs.python.org/3/library/urllib.request.html#urllib.request.ProxyHandler
             "https": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
             "http": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
-            "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+            # The ProxyHandler uses `no` for the no_proxy key
+            # https://github.com/python/cpython/blob/3.12/Lib/urllib/request.py#L2553
+            "no": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
         }
         proxies = {k: v for k, v in proxies.items() if v != ""} or None
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -2097,8 +2097,8 @@ class LogProxyConsumer(ConsumerBase):
         # If no Juju proxy variable was set, we set proxies to None to let the ProxyHandler get
         # the proxy env variables from the environment
         proxies = {
-            "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
-            "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            "https": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+            "http": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
             "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
         }
         proxies = {k: v for k, v in proxies.items() if v != ""} or None

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -518,7 +518,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Issue
[In the last episode](https://github.com/canonical/loki-k8s-operator/pull/352) we fixed the logic around setting the keys of the input `proxies` dict to the ProxyHandler. In this one, our heroes learn about a tragic mistake they made during their hard fought battle: [the keys should be the protocol names only, without the `_proxy` suffix](https://docs.python.org/3/library/urllib.request.html#urllib.request.ProxyHandler).


## Solution
With this new knowledge in hand, the happy gathering decided that all this was a learning experience and as Nicolas Boileau wrote in "L'Art poétique":
> Hâtez-vous lentement, et, sans perdre courage,
Vingt fois sur le métier remettez votre ouvrage

The mistake was promptly fixed and life was beautiful.
The end.