### PR TITLE
Catch URLError instead of HTTPError

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -490,7 +490,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib import request
-from urllib.error import HTTPError
+from urllib.error import URLError
 
 import yaml
 from cosl import JujuTopology
@@ -2326,7 +2326,7 @@ class LogProxyConsumer(ConsumerBase):
 
         try:
             self._obtain_promtail(promtail_binaries[self._arch], container)
-        except HTTPError as e:
+        except URLError as e:
             msg = f"Promtail binary couldn't be downloaded - {str(e)}"
             logger.warning(msg)
             self.on.promtail_digest_error.emit(msg)

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -519,7 +519,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Issue
When promtail download fails due to proxy not being set up, the charm [goes into error state](https://bugs.launchpad.net/juju/+bug/2056193):

```
unit-httprequest-lego-provider-0: 14:38:24 ERROR unit.httprequest-lego-provider/0.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/usr/lib/python3.10/urllib/request.py", line 1348, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
  File "/usr/lib/python3.10/http/client.py", line 1283, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1329, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1278, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1038, in _send_output
    self.send(msg)
  File "/usr/lib/python3.10/http/client.py", line 976, in send
    self.connect()
  File "/usr/lib/python3.10/http/client.py", line 1448, in connect
    super().connect()
  File "/usr/lib/python3.10/http/client.py", line 942, in connect
    self.sock = self._create_connection(
  File "/usr/lib/python3.10/socket.py", line 845, in create_connection
    raise err
  File "/usr/lib/python3.10/socket.py", line 833, in create_connection
    sock.connect(sa)
TimeoutError: [Errno 110] Connection timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/./src/charm.py", line 98, in <module>
    ops.main.main(DjangoCharm)
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/venv/ops/main.py", line 456, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/venv/ops/main.py", line 144, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/venv/ops/framework.py", line 352, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/venv/ops/framework.py", line 865, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/venv/ops/framework.py", line 955, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/lib/charms/loki_k8s/v0/loki_push_api.py", line 1821, in _on_pebble_ready
    self._setup_promtail()
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/lib/charms/loki_k8s/v0/loki_push_api.py", line 2318, in _setup_promtail
    self._obtain_promtail(promtail_binaries[self._arch])
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/lib/charms/loki_k8s/v0/loki_push_api.py", line 1991, in _obtain_promtail
    self._download_and_push_promtail_to_workload(promtail_info)
  File "/var/lib/juju/agents/unit-httprequest-lego-provider-0/charm/lib/charms/loki_k8s/v0/loki_push_api.py", line 2132, in _download_and_push_promtail_to_workload
    with opener.open(promtail_info["url"]) as r:
  File "/usr/lib/python3.10/urllib/request.py", line 519, in open
    response = self._open(req, data)
  File "/usr/lib/python3.10/urllib/request.py", line 536, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.10/urllib/request.py", line 1391, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/usr/lib/python3.10/urllib/request.py", line 1351, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno 110] Connection timed out>
unit-httprequest-lego-provider-0: 14:38:24 ERROR juju.worker.uniter.operation hook "django-app-pebble-ready" (via hook dispatching script: dispatch) failed: exit status 1
```


## Solution
Catch URLError instead of HTTPError (which inherits URLError):

> The [urllib.error](https://docs.python.org/3/library/urllib.error.html#module-urllib.error) module defines the exception classes for exceptions raised by [urllib.request](https://docs.python.org/3/library/urllib.request.html#module-urllib.request). The base exception class is [URLError](https://docs.python.org/3/library/urllib.error.html#urllib.error.URLError).


## Context
Proxy envvars were fixed in #357, and this PR is to prevent that charm from going into error state.

> I would guess that ‘django-app’ probably could be doing a lot of things that isn’t forwarding its logs to loki in the meantime. @jameinel [on charmhub](https://discourse.charmhub.io/t/its-probably-ok-for-a-unit-to-go-into-error-state/13022/32).