### PR TITLE
Enhance SSL Certificate Handling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -162,7 +162,7 @@ class LokiOperatorCharm(CharmBase):
             self,
             relation_name="ingress",
             port=self._port,
-            scheme=lambda: "https" if self._tls_ready else "http",
+            scheme=lambda: "https" if self._tls_ready_on_disk else "http",
             strip_prefix=True,
         )
         self.framework.observe(self.ingress_per_unit.on.ready_for_unit, self._on_ingress_changed)
@@ -194,7 +194,7 @@ class LokiOperatorCharm(CharmBase):
         self.loki_provider = LokiPushApiProvider(
             self,
             address=external_url.hostname or self.hostname,
-            port=external_url.port or 443 if self._tls_ready else 80,
+            port=external_url.port or 443 if self._tls_ready_on_disk else 80,
             scheme=external_url.scheme,
             path=f"{external_url.path}/loki/api/v1/push",
         )
@@ -342,13 +342,14 @@ class LokiOperatorCharm(CharmBase):
         """
         job: Dict[str, Any] = {"static_configs": [{"targets": [f"{self.hostname}:{self._port}"]}]}
 
-        if self._tls_ready:
+        if self._tls_ready_on_disk:
             job["scheme"] = "https"
 
         return [job]
 
     @property
-    def _tls_ready(self) -> bool:
+    def _tls_ready_on_disk(self) -> bool:
+        """Check if the TLS setup is ready on disk."""
         return (
             self._container.can_connect()
             and self._container.exists(CERT_FILE)
@@ -356,7 +357,8 @@ class LokiOperatorCharm(CharmBase):
         )
 
     @property
-    def _is_cert_available(self) -> bool:
+    def _cert_available_in_reldata(self) -> bool:
+        """Check if the certificate is available in relation data."""
         return (
             self.server_cert.enabled
             and (self.server_cert.cert is not None)
@@ -400,7 +402,7 @@ class LokiOperatorCharm(CharmBase):
 
         # At this point we're already after the can_connect guard, so if the following pebble operations fail, better
         # to let the charm go into error state than setting blocked.
-        if self._is_cert_available and not self._tls_ready:
+        if self._cert_available_in_reldata and not self._tls_ready_on_disk:
             self._update_cert()
         restart = self._update_config(config) or restart
 
@@ -418,7 +420,7 @@ class LokiOperatorCharm(CharmBase):
             return  # TODO: why do we have a return here?
 
         self.ingress_per_unit.provide_ingress_requirements(
-            scheme="https" if self._tls_ready else "http", port=self._port
+            scheme="https" if self._tls_ready_on_disk else "http", port=self._port
         )
         self.metrics_provider.update_scrape_job_spec(self.scrape_jobs)
         self.grafana_source_provider.update_source(source_url=self._external_url)
@@ -440,7 +442,7 @@ class LokiOperatorCharm(CharmBase):
 
         ca_cert_path = Path(self._ca_cert_path)
 
-        if self._is_cert_available:
+        if self._cert_available_in_reldata:
             # Save the workload certificates
             self._container.push(
                 CERT_FILE,
@@ -563,7 +565,7 @@ class LokiOperatorCharm(CharmBase):
     @property
     def _internal_url(self) -> str:
         """Return the fqdn dns-based in-cluster (private) address of the loki api server."""
-        scheme = "https" if self._tls_ready else "http"
+        scheme = "https" if self._tls_ready_on_disk else "http"
         return f"{scheme}://{socket.getfqdn()}:{self._port}"
 
     def _check_alert_rules(self):


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/loki-k8s-operator/issues/360 

## Context
SSL certificate verification failures can occur intermittently when [this file](https://github.com/canonical/loki-k8s-operator/blob/5f8c4b47ca302029ea39f3a9d7401e45c703e215/src/charm.py#L109) isn't present, leading to errors in connecting to the Loki API.

## Solution
The solution involves implementing a guard mechanism to handle the missing certificates, This will prevent SSL certificate verification errors like "certificate verify failed: unable to get local issuer certificate".


## Testing Instructions
1. Deploy cos-lite with the `tls-overlay`
2. Deploy `grafana-agent` and relate to a couple of charms that can push logs to Loki
3. Confirm that Loki is up and logs are being cascaded normally
