### PR TITLE
fix: use set_ports instead of open_port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -127,7 +127,7 @@ class LokiOperatorCharm(CharmBase):
         )
 
         self._container = self.unit.get_container(self._name)
-        self.unit.open_port(protocol="tcp", port=self._port)
+        self.unit.set_ports(self._port)
 
         # If Loki is run in single-tenant mode, all the chunks are put in a folder named "fake"
         # https://grafana.com/docs/loki/latest/operations/storage/filesystem/


### PR DESCRIPTION
## Issue

`open_port` doesn't close ports; if the port changes on upgrades, the previous one isn't closed.

## Solution

Use `set_ports` instead, as documented [here](https://github.com/canonical/operator/blob/ab239e1156bd206f9825b5be96fbf83121489fee/ops/model.py#L699).