### PR TITLE
Adding TSBD storage to Loki and switching to v12 schema

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,23 +34,13 @@ containers:
         location: /loki/boltdb-shipper-active
       - storage: loki-chunks
         location: /loki/chunks
-      - storage: loki-wal
-        location: /loki/wal
-      - storage: tsdb-index
-        location: /loki/tsdb-index
 storage:
   active-index-directory:
     type: filesystem
     description: Mount point in which Loki will store index
-  tsdb-index:
-    type: filesystem
-    description: Mount point in which Loki will store TSDB indices
   loki-chunks:
     type: filesystem
     description: Mount point in which Loki will store chunks (objects)
-  loki-wal:
-    type: filesystem
-    description: Mount point in which Loki will store write ahead logs
 
 
 provides:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,6 +34,7 @@ containers:
         location: /loki/boltdb-shipper-active
       - storage: loki-chunks
         location: /loki/chunks
+
 storage:
   active-index-directory:
     type: filesystem
@@ -41,7 +42,6 @@ storage:
   loki-chunks:
     type: filesystem
     description: Mount point in which Loki will store chunks (objects)
-
 
 provides:
   logging:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -42,6 +42,8 @@ containers:
       - storage: loki-chunks
         location: /loki/chunks
 
+# We do not need separate storages. TODO: In the next breaking change for Loki,
+# switch to having just one persisted storage, e.g. `/loki/persisted`.
 storage:
   active-index-directory:
     type: filesystem

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,14 +34,24 @@ containers:
         location: /loki/boltdb-shipper-active
       - storage: loki-chunks
         location: /loki/chunks
-
+      - storage: loki-wal
+        location: /loki/wal
+      - storage: tsdb-index
+        location: /loki/tsdb-index
 storage:
   active-index-directory:
     type: filesystem
     description: Mount point in which Loki will store index
+  tsdb-index:
+    type: filesystem
+    description: Mount point in which Loki will store TSDB indices
   loki-chunks:
     type: filesystem
     description: Mount point in which Loki will store chunks (objects)
+  loki-wal:
+    type: filesystem
+    description: Mount point in which Loki will store write ahead logs
+
 
 provides:
   logging:

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,7 @@ import subprocess
 import time
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -481,11 +481,11 @@ class LokiOperatorCharm(CharmBase):
         # By default, we assume it's a fresh installation unless explicitly set to False
         # by the upgrade hook, indicating an upgrade
         if not v12_migration_date:
-            v12_migration_date = (datetime.date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+            v12_migration_date = (datetime.date.today() + datetime.timedelta(days=1)).strftime(
+                "%Y-%m-%d"
+            )
             if is_fresh_installation:
-                v12_migration_date = datetime.date.today().strftime(
-                    "%Y-%m-%d"
-                )
+                v12_migration_date = datetime.date.today().strftime("%Y-%m-%d")
 
         config = ConfigBuilder(
             instance_addr=self.hostname,

--- a/src/charm.py
+++ b/src/charm.py
@@ -481,12 +481,9 @@ class LokiOperatorCharm(CharmBase):
         # By default, we assume it's a fresh installation unless explicitly set to False
         # by the upgrade hook, indicating an upgrade
         if not v12_migration_date:
+            v12_migration_date = (datetime.date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
             if is_fresh_installation:
-                v12_migration_date = v12_migration_date = datetime.date.today().strftime(
-                    "%Y-%m-%d"
-                )
-            else:
-                v12_migration_date = (datetime.date.today() + datetime.timedelta(days=1)).strftime(
+                v12_migration_date = datetime.date.today().strftime(
                     "%Y-%m-%d"
                 )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -465,7 +465,7 @@ class LokiOperatorCharm(CharmBase):
         current_layer = self._loki_container.get_plan()
         new_layer = self._build_pebble_layer
         restart = current_layer.services != new_layer.services
-        v12_migration = self._get_v12_from_date() or (
+        v12_migration_date = self._get_v12_migration_date() or (
             datetime.date.today() + datetime.timedelta(days=1)
         ).strftime("%Y-%m-%d")
 
@@ -477,7 +477,7 @@ class LokiOperatorCharm(CharmBase):
             ingestion_burst_size_mb=int(self.config["ingestion-burst-size-mb"]),
             retention_period=int(self.config["retention-period"]),
             http_tls=(self.server_cert.server_cert is not None),
-            v12_from=v12_migration,
+            v12_migration_date=v12_migration_date,
         ).build()
 
         # At this point we're already after the can_connect guard, so if the following pebble operations fail, better
@@ -571,7 +571,7 @@ class LokiOperatorCharm(CharmBase):
 
         return ",".join(alertmanagers)
 
-    def _get_v12_from_date(self) -> str:
+    def _get_v12_migration_date(self) -> str:
         """Get the 'from' date from the v12 schema in Loki config."""
         running_config = self._running_config()
         if running_config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -587,8 +587,7 @@ class LokiOperatorCharm(CharmBase):
         In 2024-05 we changed the storage backend the charm configures from v11/boltdb to v12/tsdb.
 
         Returns:
-        str: If v12 schema is found, returns the 'from' date of the v12 schema
-                        in ISO 8601 format (YYYY-MM-DD), otherwise returns empty string.
+            The 'from' date of the v12 schema, in YYYY-MM-DD format (ISO 8601), if it is found; otherwise empty string.
         """
         if not self._loki_container.can_connect():
             return ""
@@ -598,7 +597,8 @@ class LokiOperatorCharm(CharmBase):
             )
         except PathError:
             return ""
-
+        except yaml.YAMLError as e:
+            raise RuntimeError(f"Error parsing Loki backup config: {e}")
         for config in running_config.get("schema_config", {}).get("configs", []):
             if config.get("schema") == "v12":
                 return config.get("from", "")

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -119,29 +119,24 @@ class ConfigBuilder:
 
     @property
     def _schema_config(self) -> dict:
-        configs = [
-            {
-                "from": "2020-10-24",
-                "index": {"period": "24h", "prefix": "index_"},
-                "object_store": "filesystem",
-                "schema": "v11",
-                "store": "boltdb-shipper",
-            }
-        ]
-        # Only render the v12/tsdb section when we can reliably obtain a "from" date.
-        # This is needed to avoid code ordering issues during upgrade, related to "can_connect".
-        if self.v12_migration_date:
-            configs.append(
+        return {
+            "configs": [
+                {
+                    "from": "2020-10-24",
+                    "index": {"period": "24h", "prefix": "index_"},
+                    "object_store": "filesystem",
+                    "schema": "v11",
+                    "store": "boltdb-shipper",
+                },
                 {
                     "from": self.v12_migration_date,
                     "index": {"period": "24h", "prefix": "index_"},
                     "object_store": "filesystem",
                     "schema": "v12",
                     "store": "tsdb",
-                }
-            )
-
-        return {"configs": configs}
+                },
+            ]
+        }
 
     @property
     def _server(self) -> dict:
@@ -160,23 +155,20 @@ class ConfigBuilder:
 
     @property
     def _storage_config(self) -> dict:
-        storage_config = {
+        # Ref: https://grafana.com/docs/loki/latest/configure/#storage_config
+        return {
             "boltdb_shipper": {
                 "active_index_directory": BOLTDB_DIR,
                 "shared_store": "filesystem",
                 "cache_location": BOLTDB_CACHE_DIR,
             },
-            "filesystem": {"directory": CHUNKS_DIR},
-        }
-
-        if self.v12_migration_date:
-            storage_config["tsdb_shipper"] = {
+            "tsdb_shipper": {
                 "active_index_directory": TSDB_DIR,
                 "shared_store": "filesystem",
                 "cache_location": TSDB_CACHE_DIR,
-            }
-
-        return storage_config
+            },
+            "filesystem": {"directory": CHUNKS_DIR},
+        }
 
     @property
     def _limits_config(self) -> dict:

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -16,6 +16,7 @@ KEY_FILE = os.path.join(LOKI_CERTS_DIR, "loki.key.pem")
 
 LOKI_DIR = "/loki"
 CHUNKS_DIR = os.path.join(LOKI_DIR, "chunks")
+LOKI_CONFIG_PERSISTED = os.path.join(CHUNKS_DIR, "loki-local-config.yaml")
 COMPACTOR_DIR = os.path.join(LOKI_DIR, "compactor")
 BOLTDB_DIR = os.path.join(LOKI_DIR, "boltdb-shipper-active")
 BOLTDB_CACHE_DIR = os.path.join(LOKI_DIR, "boltdb-shipper-cache")

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -127,7 +127,7 @@ class ConfigBuilder:
                 "store": "boltdb-shipper",
             }
         ]
-
+        # Only render the v12/tsdb section when we can reliably obtain a "from" date.
         if self.v12_migration_date:
             configs.append(
                 {

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -16,9 +16,12 @@ KEY_FILE = os.path.join(LOKI_CERTS_DIR, "loki.key.pem")
 
 LOKI_DIR = "/loki"
 CHUNKS_DIR = os.path.join(LOKI_DIR, "chunks")
+WAL_DIR = os.path.join(LOKI_DIR, "wal")
 COMPACTOR_DIR = os.path.join(LOKI_DIR, "compactor")
 BOLTDB_DIR = os.path.join(LOKI_DIR, "boltdb-shipper-active")
 BOLTDB_CACHE_DIR = os.path.join(LOKI_DIR, "boltdb-shipper-cache")
+TSDB_DIR = os.path.join(LOKI_DIR, "tsdb-index")
+TSDB_CACHE_DIR = os.path.join(LOKI_DIR, "tsdb-cache")
 RULES_DIR = os.path.join(LOKI_DIR, "rules")
 
 
@@ -91,7 +94,7 @@ class ConfigBuilder:
     def _ingester(self) -> dict:
         return {
             "wal": {
-                "dir": os.path.join(CHUNKS_DIR, "wal"),
+                "dir": WAL_DIR,
                 "enabled": True,
                 "flush_on_shutdown": True,
             }
@@ -115,7 +118,14 @@ class ConfigBuilder:
                     "object_store": "filesystem",
                     "schema": "v11",
                     "store": "boltdb-shipper",
-                }
+                },
+                {
+                    "from": "2024-04-24",
+                    "index": {"period": "24h", "prefix": "index_"},
+                    "object_store": "filesystem",
+                    "schema": "v12",
+                    "store": "tsdb",
+                },
             ]
         }
 
@@ -142,6 +152,11 @@ class ConfigBuilder:
                 "active_index_directory": BOLTDB_DIR,
                 "shared_store": "filesystem",
                 "cache_location": BOLTDB_CACHE_DIR,
+            },
+            "boltdb_shipper": {
+                "active_index_directory": TSDB_DIR,
+                "shared_store": "filesystem",
+                "cache_location": TSDB_CACHE_DIR,
             },
             "filesystem": {"directory": CHUNKS_DIR},
         }

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -42,7 +42,7 @@ class ConfigBuilder:
         instance_addr: str,
         alertmanager_url: str,
         external_url: str,
-        v12_from: str,
+        v12_migration_date: str,
         ingestion_rate_mb: int,
         ingestion_burst_size_mb: int,
         retention_period: int,
@@ -56,7 +56,7 @@ class ConfigBuilder:
         self.ingestion_burst_size_mb = ingestion_burst_size_mb
         self.http_tls = http_tls
         self.retention_period = retention_period
-        self.v12_from = v12_from
+        self.v12_migration_date = v12_migration_date
 
     def build(self) -> dict:
         """Build Loki config dictionary."""
@@ -121,7 +121,7 @@ class ConfigBuilder:
                     "store": "boltdb-shipper",
                 },
                 {
-                    "from": self.v12_from,
+                    "from": self.v12_migration_date,
                     "index": {"period": "24h", "prefix": "index_"},
                     "object_store": "filesystem",
                     "schema": "v12",

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -128,6 +128,7 @@ class ConfigBuilder:
             }
         ]
         # Only render the v12/tsdb section when we can reliably obtain a "from" date.
+        # This is needed to avoid code ordering issues during upgrade, related to "can_connect".
         if self.v12_migration_date:
             configs.append(
                 {

--- a/tests/integration/test_boltdb_v11_to_tsdb_v12_migration.py
+++ b/tests/integration/test_boltdb_v11_to_tsdb_v12_migration.py
@@ -91,7 +91,6 @@ async def verify_upgrade_success(ops_test: OpsTest, app_name, is_fresh_installat
     """Verify that the upgrade was successful."""
     assert await is_loki_up(ops_test, app_name)
     post_upgrade_config = await loki_config(ops_test, app_name)
-    tsdb_shipper_config = post_upgrade_config["storage_config"]["tsdb_shipper"]
     tsdb_schema_configs = post_upgrade_config["schema_config"]["configs"][1]
 
     expected_from = (
@@ -99,15 +98,6 @@ async def verify_upgrade_success(ops_test: OpsTest, app_name, is_fresh_installat
         if is_fresh_installation
         else (datetime.date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
     )
-
-    assert all(
-        [
-            tsdb_shipper_config["active_index_directory"]
-            == "/loki/boltdb-shipper-active/tsdb-index",
-            tsdb_shipper_config["shared_store"] == "filesystem",
-            tsdb_shipper_config["cache_location"] == "/loki/tsdb-cache",
-            tsdb_schema_configs["store"] == "tsdb",
-            tsdb_schema_configs["schema"] == "v12",
-            tsdb_schema_configs["from"] == expected_from,
-        ]
-    )
+    assert tsdb_schema_configs["store"] == "tsdb"
+    assert tsdb_schema_configs["schema"] == "v12"
+    assert tsdb_schema_configs["from"] == expected_from

--- a/tests/integration/test_boltdb_v11_to_tsdb_v12_migration.py
+++ b/tests/integration/test_boltdb_v11_to_tsdb_v12_migration.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This test module tests loki upgrade to validate schema migration from v11/boltdb to v12/tsdb.
+
+Test Scenarios:
+1. Deploy from Charmhub with revision 140 using v11/boltdb, then upgrade to local charm with v12/tsdb.
+2. Deploy locally with v12/tsdb, then upgrade locally to validate configuration persistence.
+"""
+
+import datetime
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import is_loki_up, loki_config
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+V11_APP_NAME = f'v11-{METADATA["name"]}'
+V12_APP_NAME = f'v12-{METADATA["name"]}'
+
+resources = {
+    "loki-image": METADATA["resources"]["loki-image"]["upstream-source"],
+    "node-exporter-image": METADATA["resources"]["node-exporter-image"]["upstream-source"],
+}
+
+
+async def test_setup_env(ops_test: OpsTest):
+    await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_from_charmhub_v11_and_upgrade_to_v12_locally(ops_test: OpsTest, loki_charm):
+    """Deploy from Charmhub (v11 schema) and upgrade to v12 locally."""
+    await deploy_charm_from_charmhub_v11(ops_test, V11_APP_NAME)
+    await upgrade_charm_with_local_charm_v12(ops_test, V11_APP_NAME, loki_charm)
+    await verify_upgrade_success(ops_test, V11_APP_NAME, False)
+
+    # Here we upgrade again to ensure config is persisted and won't be overwritten with any weird values
+    await upgrade_charm_with_local_charm_v12(ops_test, V11_APP_NAME, loki_charm)
+    await verify_upgrade_success(ops_test, V11_APP_NAME, False)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_and_upgrade_v12_locally(ops_test: OpsTest, loki_charm):
+    """Deploy from a local charm (v12 schema) and upgrade locally."""
+    await deploy_local_charm_v12(ops_test, V12_APP_NAME, loki_charm)
+    await upgrade_charm_with_local_charm_v12(ops_test, V12_APP_NAME, loki_charm)
+    await verify_upgrade_success(ops_test, V12_APP_NAME, True)
+
+    # Here we upgrade again to ensure config is persisted and won't be overwritten with any weird values
+    await upgrade_charm_with_local_charm_v12(ops_test, V12_APP_NAME, loki_charm)
+    await verify_upgrade_success(ops_test, V12_APP_NAME, True)
+
+
+async def deploy_charm_from_charmhub_v11(ops_test: OpsTest, app_name):
+    """Deploy the charm from Charmhub."""
+    logger.debug("Deploying charm from Charmhub")
+    await ops_test.model.deploy(
+        "ch:loki-k8s",
+        application_name=app_name,
+        channel="edge",
+        revision=140,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+
+
+async def deploy_local_charm_v12(ops_test: OpsTest, app_name, loki_charm):
+    """Deploy the charm-under-test."""
+    logger.debug("deploy local charm")
+    await ops_test.model.deploy(
+        loki_charm, application_name=app_name, resources=resources, trust=True
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+
+
+async def upgrade_charm_with_local_charm_v12(ops_test: OpsTest, app_name, loki_charm):
+    """Upgrade the deployed charm with the local charm."""
+    logger.debug("Upgrading deployed charm with local charm %s", loki_charm)
+    await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+
+
+async def verify_upgrade_success(ops_test: OpsTest, app_name, is_fresh_installation: bool):
+    """Verify that the upgrade was successful."""
+    assert await is_loki_up(ops_test, app_name)
+    post_upgrade_config = await loki_config(ops_test, app_name)
+    tsdb_shipper_config = post_upgrade_config["storage_config"]["tsdb_shipper"]
+    tsdb_schema_configs = post_upgrade_config["schema_config"]["configs"][1]
+
+    expected_from = (
+        (datetime.date.today()).strftime("%Y-%m-%d")
+        if is_fresh_installation
+        else (datetime.date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    )
+
+    assert all(
+        [
+            tsdb_shipper_config["active_index_directory"]
+            == "/loki/boltdb-shipper-active/tsdb-index",
+            tsdb_shipper_config["shared_store"] == "filesystem",
+            tsdb_shipper_config["cache_location"] == "/loki/tsdb-cache",
+            tsdb_schema_configs["store"] == "tsdb",
+            tsdb_schema_configs["schema"] == "v12",
+            tsdb_schema_configs["from"] == expected_from,
+        ]
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
     ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
+# codespell pinned cause version 2.3.0 mistakenly considers joined words such as "assertIn" invalid
 [testenv:lint]
 description = Check code against coding style standards
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ description = Check code against coding style standards
 deps =
     black
     ruff
-    codespell
+    codespell<2.3.0
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache


### PR DESCRIPTION
## Issue
Fixes #362 & #380

## Solution

To avoid this becoming a breaking change in loki a few workarounds were implemented

1. TSDB data will live inside the active-index-directory originally created to accommodate boltdb, this is because adding a new PVC for it might disrupt the upgrade path as juju doesn't currently support this, this adjustment won't lead to storage overload, as all chunks, regardless of their schema, will still be directed to `/loki/chunks`
```
ERROR Juju on containers does not support updating storage on a statefulset.
The new charm's metadata contains updated storage declarations.
You'll need to deploy a new charm rather than upgrading if you need this change.
```
2. V12 schema migration date (The date for when loki will actually start to write logs in v12) will be set dynamically, with different values depending on whether it's a fresh installation or a charm upgrade. In case of a fresh installation loki will set the date to the day of installation and will set it to the day after in case of upgrade. This is achieved by dumping the loki config in the chunks persistent storage `/loki/chunks` so that next time we go through startup/upgrade we check if the file is there and render the v12 "from" to be today/tomorrow

## Context
Refer to https://github.com/canonical/loki-k8s-operator/issues/362#issuecomment-2074912569

## Upgrade Notes

**Storage Schema Bump** 
This PR bumps the Loki's storage schema to v12, which manages the `filesystem` storage far better than v11, the filesystem will use `<user>/<fingerprint>/base64Encode(<start>:<end>:<checksum>)` instead of dumping everything in the flat `chunks` directory.

**Migration to TSDB**
Starting with Loki v2.8, TSDB is the recommended Loki index. It is heavily inspired by the Prometheus’s TSDB [sub-project](https://github.com/prometheus/prometheus/tree/main/tsdb). For a deeper explanation you can read Loki maintainer Owen’s [blog post](https://lokidex.com/posts/tsdb/). The short version is that this new index is more efficient, faster, and more scalable. It also resides in object storage like the [boltdb-shipper](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/) index which preceded it.

