### PR TITLE
Loki alerts are not being pushed to AlertManager

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -103,6 +103,7 @@ class ConfigBuilder:
         return {
             "alertmanager_url": self.alertmanager_url,
             "external_url": self.external_url,
+            "enable_alertmanager_v2": True,
         }
 
     @property


### PR DESCRIPTION
## Issue
Fixes #396 

## Solution
Use alertmanager's API v2 instead of removed v1

