### PR TITLE
Add deprecation warning for LogProxyConsumer

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -16,9 +16,10 @@ The provider side of the relation represents the server side, to which logs are 
   applications such as pebble, or charmed operators of workloads such as grafana-agent or promtail,
   that can communicate with loki directly.
 
-- `LogProxyConsumer`: This object can be used by any Charmed Operator which needs to
-send telemetry, such as logs, to Loki through a Log Proxy by implementing the consumer side of the
-`loki_push_api` relation interface.
+- `LogProxyConsumer`: DEPRECATED.
+This object can be used by any Charmed Operator which needs to send telemetry, such as logs, to
+Loki through a Log Proxy by implementing the consumer side of the `loki_push_api` relation
+interface.
 
 Filtering logs in Loki is largely performed on the basis of labels. In the Juju ecosystem, Juju
 topology labels are used to uniquely identify the workload which generates telemetry like logs.
@@ -38,13 +39,14 @@ and three optional arguments.
 - `charm`: A reference to the parent (Loki) charm.
 
 - `relation_name`: The name of the relation that the charm uses to interact
-  with its clients, which implement `LokiPushApiConsumer` or `LogProxyConsumer`.
+  with its clients, which implement `LokiPushApiConsumer` or `LogProxyConsumer`
+  (note that LogProxyConsumer is deprecated).
 
   If provided, this relation name must match a provided relation in metadata.yaml with the
   `loki_push_api` interface.
 
   The default relation name is "logging" for `LokiPushApiConsumer` and "log-proxy" for
-  `LogProxyConsumer`.
+  `LogProxyConsumer` (note that LogProxyConsumer is deprecated).
 
   For example, a provider's `metadata.yaml` file may look as follows:
 
@@ -218,6 +220,9 @@ labels in charm code. See :func:`LogProxyConsumer._scrape_configs` for an exampl
 to do this with promtail.
 
 ## LogProxyConsumer Library Usage
+
+> Note: This object is deprecated. Consider migrating to LogForwarder (see v1/loki_push_api) with
+> the release of Juju 3.6 LTS.
 
 Let's say that we have a workload charm that produces logs, and we need to send those logs to a
 workload implementing the `loki_push_api` interface, such as `Loki` or `Grafana Agent`.
@@ -480,7 +485,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 29
+LIBPATCH = 30
 
 PYDEPS = ["cosl"]
 
@@ -1539,7 +1544,8 @@ class LokiPushApiConsumer(ConsumerBase):
         the Loki API endpoint to push logs. It is intended for workloads that can speak
         loki_push_api (https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki), such
         as grafana-agent.
-        (If you only need to forward a few workload log files, then use LogProxyConsumer.)
+        (If you need to forward workload stdout logs, then use v1/loki_push_api.LogForwarder; if
+        you need to forward log files, then use LogProxyConsumer.)
 
         `LokiPushApiConsumer` can be instantiated as follows:
 
@@ -1727,6 +1733,9 @@ class LogProxyEvents(ObjectEvents):
 
 class LogProxyConsumer(ConsumerBase):
     """LogProxyConsumer class.
+
+    > Note: This object is deprecated. Consider migrating to v1/loki_push_api.LogForwarder with the
+    > release of Juju 3.6 LTS.
 
     The `LogProxyConsumer` object provides a method for attaching `promtail` to
     a workload in order to generate structured logging data from applications

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -17,15 +17,14 @@ This library
 send log to Loki by implementing the consumer side of the `loki_push_api` relation interface.
 For instance, a Promtail or Grafana agent charm which needs to send logs to Loki.
 
-- `LogProxyConsumer`: SCHEDULED FOR DEPRECATION.
+- `LogProxyConsumer`: DEPRECATED.
 This object can be used by any Charmed Operator which needs to send telemetry, such as logs, to
 Loki through a Log Proxy by implementing the consumer side of the `loki_push_api` relation
 interface.
 In order to be able to control the labels on the logs pushed this object adds a Pebble layer
 that runs Promtail in the workload container, injecting Juju topology labels into the
 logs on the fly.
-This object is scheduled for deprecation with the release and adoption of Juju 3.6 LTS.
-Consider migrating to LogForwarder.
+This object is deprecated. Consider migrating to LogForwarder with the release of Juju 3.6 LTS.
 
 - `LogForwarder`: This object can be used by any Charmed Operator which needs to send the workload
 standard output (stdout) through Pebble's log forwarding mechanism, to Loki endpoints through the
@@ -49,13 +48,13 @@ and three optional arguments.
 
 - `relation_name`: The name of the relation that the charm uses to interact
   with its clients, which implement `LokiPushApiConsumer` `LogForwarder`, or `LogProxyConsumer`
-  (note that LogProxyConsumer is scheduled for deprecation).
+  (note that LogProxyConsumer is deprecated).
 
   If provided, this relation name must match a provided relation in metadata.yaml with the
   `loki_push_api` interface.
 
   The default relation name is "logging" for `LokiPushApiConsumer` and `LogForwarder`, and
-  "log-proxy" for `LogProxyConsumer` (note that LogProxyConsumer is scheduled for deprecation).
+  "log-proxy" for `LogProxyConsumer` (note that LogProxyConsumer is deprecated).
 
   For example, a provider's `metadata.yaml` file may look as follows:
 
@@ -230,8 +229,8 @@ to do this with promtail.
 
 ## LogProxyConsumer Library Usage
 
-> Note: This object is scheduled for deprecation with the release and adoption of Juju 3.6 LTS.
-> Consider migrating to LogForwarder.
+> Note: This object is deprecated. Consider migrating to LogForwarder with the release of Juju 3.6
+> LTS.
 
 Let's say that we have a workload charm that produces logs, and we need to send those logs to a
 workload implementing the `loki_push_api` interface, such as `Loki` or `Grafana Agent`.
@@ -1779,8 +1778,8 @@ class LogProxyEvents(ObjectEvents):
 class LogProxyConsumer(ConsumerBase):
     """LogProxyConsumer class.
 
-    > Note: This object is scheduled for deprecation with the release and adoption of Juju 3.6 LTS.
-    > Consider migrating to LogForwarder.
+    > Note: This object is deprecated. Consider migrating to LogForwarder with the release of Juju
+    > 3.6 LTS.
 
     The `LogProxyConsumer` object provides a method for attaching `promtail` to
     a workload in order to generate structured logging data from applications

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -11,7 +11,6 @@ This document explains how to use the two principal objects this library provide
 - `LokiPushApiProvider`: This object is meant to be used by any Charmed Operator that needs to
 implement the provider side of the `loki_push_api` relation interface. For instance, a Loki charm.
 The provider side of the relation represents the server side, to which logs are being pushed.
-This library
 
 - `LokiPushApiConsumer`: This object is meant to be used by any Charmed Operator that needs to
 send log to Loki by implementing the consumer side of the `loki_push_api` relation interface.

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -11,25 +11,31 @@ This document explains how to use the two principal objects this library provide
 - `LokiPushApiProvider`: This object is meant to be used by any Charmed Operator that needs to
 implement the provider side of the `loki_push_api` relation interface. For instance, a Loki charm.
 The provider side of the relation represents the server side, to which logs are being pushed.
+This library
 
 - `LokiPushApiConsumer`: This object is meant to be used by any Charmed Operator that needs to
 send log to Loki by implementing the consumer side of the `loki_push_api` relation interface.
 For instance, a Promtail or Grafana agent charm which needs to send logs to Loki.
 
-- `LogProxyConsumer`: This object can be used by any Charmed Operator which needs to
-send telemetry, such as logs, to Loki through a Log Proxy by implementing the consumer side of the
-`loki_push_api` relation interface.
+- `LogProxyConsumer`: SCHEDULED FOR DEPRECATION.
+This object can be used by any Charmed Operator which needs to send telemetry, such as logs, to
+Loki through a Log Proxy by implementing the consumer side of the `loki_push_api` relation
+interface.
+In order to be able to control the labels on the logs pushed this object adds a Pebble layer
+that runs Promtail in the workload container, injecting Juju topology labels into the
+logs on the fly.
+This object is scheduled for deprecation with the release and adoption of Juju 3.6 LTS.
+Consider migrating to LogForwarder.
 
 - `LogForwarder`: This object can be used by any Charmed Operator which needs to send the workload
 standard output (stdout) through Pebble's log forwarding mechanism, to Loki endpoints through the
 `loki_push_api` relation interface.
+In order to be able to control the labels on the logs pushed this object updates the pebble layer's
+"log-targets" section with Juju topology.
 
 Filtering logs in Loki is largely performed on the basis of labels. In the Juju ecosystem, Juju
 topology labels are used to uniquely identify the workload which generates telemetry like logs.
 
-In order to be able to control the labels on the logs pushed this object adds a Pebble layer
-that runs Promtail in the workload container, injecting Juju topology labels into the
-logs on the fly.
 
 ## LokiPushApiProvider Library Usage
 
@@ -42,13 +48,14 @@ and three optional arguments.
 - `charm`: A reference to the parent (Loki) charm.
 
 - `relation_name`: The name of the relation that the charm uses to interact
-  with its clients, which implement `LokiPushApiConsumer` or `LogProxyConsumer`.
+  with its clients, which implement `LokiPushApiConsumer` `LogForwarder`, or `LogProxyConsumer`
+  (note that LogProxyConsumer is scheduled for deprecation).
 
   If provided, this relation name must match a provided relation in metadata.yaml with the
   `loki_push_api` interface.
 
-  The default relation name is "logging" for `LokiPushApiConsumer` and "log-proxy" for
-  `LogProxyConsumer`.
+  The default relation name is "logging" for `LokiPushApiConsumer` and `LogForwarder`, and
+  "log-proxy" for `LogProxyConsumer` (note that LogProxyConsumer is scheduled for deprecation).
 
   For example, a provider's `metadata.yaml` file may look as follows:
 
@@ -222,6 +229,9 @@ labels in charm code. See :func:`LogProxyConsumer._scrape_configs` for an exampl
 to do this with promtail.
 
 ## LogProxyConsumer Library Usage
+
+> Note: This object is scheduled for deprecation with the release and adoption of Juju 3.6 LTS.
+> Consider migrating to LogForwarder.
 
 Let's say that we have a workload charm that produces logs, and we need to send those logs to a
 workload implementing the `loki_push_api` interface, such as `Loki` or `Grafana Agent`.
@@ -519,7 +529,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["cosl"]
 
@@ -1593,7 +1603,8 @@ class LokiPushApiConsumer(ConsumerBase):
         the Loki API endpoint to push logs. It is intended for workloads that can speak
         loki_push_api (https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki), such
         as grafana-agent.
-        (If you only need to forward a few workload log files, then use LogProxyConsumer.)
+        (If you need to forward workload stdout logs, then use LogForwarder; if you need to forward
+        log files, then use LogProxyConsumer.)
 
         `LokiPushApiConsumer` can be instantiated as follows:
 
@@ -1767,6 +1778,9 @@ class LogProxyEvents(ObjectEvents):
 
 class LogProxyConsumer(ConsumerBase):
     """LogProxyConsumer class.
+
+    > Note: This object is scheduled for deprecation with the release and adoption of Juju 3.6 LTS.
+    > Consider migrating to LogForwarder.
 
     The `LogProxyConsumer` object provides a method for attaching `promtail` to
     a workload in order to generate structured logging data from applications


### PR DESCRIPTION
## Issue
We have an external dependency on promtail, which the charm lib (LogProxyConsumer) attempts to download from a hard-coded URL. This dependency is inconvenient to work around with in air-gapped environments.

## Solution
Encourage users to migrate to LogForwarder by deprecating LogProxyConsumer.
1. LogProxyConsumer will be omitted from v2 of loki_push_api, but v0 and v1 are still available. Users who are happy with having the promtail dependency, can keep using it without change, and future changes to the loki lib won't break backwards compatibility as far as it comes to promtail.
1. No deprecation warnings are added in this PR, to avoid unnecessary (and inaccurate) messaging.

Closes https://github.com/canonical/grafana-agent-k8s-operator/issues/300.


## Context
- Pebble log forwarding support was added in Juju 3.4.1.
- https://discourse.charmhub.io/t/promtail-based-log-streaming-to-loki-logproxyconsumer-is-scheduled-for-deprecation/14289

Y-statement: 
- I the context of streaming logs to loki,
- facing the concern that promtail isn't readily available in air-gapped environments,
- we decided to go forward only with LogForwarder, requiring Juju >= 3.4.1,
- and rejected potential solutions for making promtail available via PYDEPS or a fileserver,
- to achieve a coherent, uniform solution without external dependencies that relies on pebble log forwarding,
- accepting the downside that logging to loki won't be available in k8s models with Juju < 3.4.1.

## Testing Instructions
See example in https://github.com/canonical/postgresql-k8s-operator/pull/486.

## Upgrade Notes
If, in a model with Juju < 3.4.1, an admin refreshes a charm that migrated from LogProxyConsumer to LogForwarder, then logs won't be forwarded anymore. (There will be no effect if there aren't any logging relations to loki in place.)