### PR TITLE
fix: use UTC time in loki schema definition

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -502,7 +502,7 @@ class LokiOperatorCharm(CharmBase):
         # by the upgrade hook, indicating an upgrade
 
         if not (v12_migration_date := self.get_v12_migration_date_from_backup()):
-            today = datetime.date.today()
+            today = datetime.datetime.now(datetime.timezone.utc)
             tomorrow = today + datetime.timedelta(days=1)
             v12_migration_date = (today if self._stored.fresh_install else tomorrow).strftime(
                 "%Y-%m-%d"


### PR DESCRIPTION
Loki's schema config `from` field uses dates in UTC to define what schema is applicable when.  Previously, this charm wrote the date in local time, which will lead to an inconsistency for a few hours (see https://grafana.com/docs/loki/latest/operations/storage/schema/#changing-the-schema).  This change addresses the issue, always using UTC time
