### PR TITLE
Improve exceptions handling and add can_connect guards

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -2562,10 +2562,9 @@ class LogForwarder(ConsumerBase):
             return
 
         for container in self._charm.unit.containers.values():
-            if not container.can_connect():
-                continue
-
-            self._update_endpoints(container, loki_endpoints)
+            if container.can_connect():
+                self._update_endpoints(container, loki_endpoints)
+            # else: `_update_endpoints` will be called on pebble-ready anyway.
 
     def _retrieve_endpoints_from_relation(self) -> dict:
         loki_endpoints = {}

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -527,7 +527,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["cosl"]
 
@@ -2475,6 +2475,9 @@ class _PebbleLogClient:
         container: Container, active_endpoints: Dict[str, str], topology: JujuTopology
     ):
         """Disable forwarding for inactive endpoints by checking against the Pebble plan."""
+        if not container.can_connect():
+            return
+
         pebble_layer = container.get_plan().to_dict().get("log-targets", None)
         if not pebble_layer:
             return
@@ -2501,6 +2504,9 @@ class _PebbleLogClient:
         container: Container, active_endpoints: Dict[str, str], topology: JujuTopology
     ):
         """Enable forwarding for the specified Loki endpoints."""
+        if not container.can_connect():
+            return
+
         layer = Layer(
             {  # pyright: ignore
                 "log-targets": _PebbleLogClient._build_log_targets(

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -2475,9 +2475,6 @@ class _PebbleLogClient:
         container: Container, active_endpoints: Dict[str, str], topology: JujuTopology
     ):
         """Disable forwarding for inactive endpoints by checking against the Pebble plan."""
-        if not container.can_connect():
-            return
-
         pebble_layer = container.get_plan().to_dict().get("log-targets", None)
         if not pebble_layer:
             return
@@ -2504,9 +2501,6 @@ class _PebbleLogClient:
         container: Container, active_endpoints: Dict[str, str], topology: JujuTopology
     ):
         """Enable forwarding for the specified Loki endpoints."""
-        if not container.can_connect():
-            return
-
         layer = Layer(
             {  # pyright: ignore
                 "log-targets": _PebbleLogClient._build_log_targets(
@@ -2568,6 +2562,9 @@ class LogForwarder(ConsumerBase):
             return
 
         for container in self._charm.unit.containers.values():
+            if not container.can_connect():
+                continue
+
             self._update_endpoints(container, loki_endpoints)
 
     def _retrieve_endpoints_from_relation(self) -> dict:

--- a/src/charm.py
+++ b/src/charm.py
@@ -66,7 +66,7 @@ from ops.model import (
     StatusBase,
     WaitingStatus,
 )
-from ops.pebble import Error, Layer, PathError, ProtocolError
+from ops.pebble import ConnectionError, Error, ExecError, Layer, PathError, ProtocolError
 
 # To keep a tidy debug-log, we suppress some DEBUG/INFO logs from some imported libs,
 # even when charm logging is set to a lower level.
@@ -566,12 +566,16 @@ class LokiOperatorCharm(CharmBase):
         return False
 
     def _update_cert(self):
-        if not self._loki_container.can_connect():
-            return
-
-        ca_cert_path = Path(self._ca_cert_path)
-
         if self.server_cert.available:
+            self._push_cert_files()
+        else:
+            self._remove_cert_files()
+
+        self._update_ca_certificates()
+
+    def _push_cert_files(self):
+        ca_cert_path = Path(self._ca_cert_path)
+        try:
             # Save the workload certificates
             self._loki_container.push(
                 CERT_FILE,
@@ -589,21 +593,36 @@ class LokiOperatorCharm(CharmBase):
                 self.server_cert.ca_cert,  # pyright: ignore
                 make_dirs=True,
             )
+        except ConnectionError:
+            logger.error("Could not push cert files. Pebble refused connection. Shutting down?")
+            return
 
-            # Repeat for the charm container. We need it there for loki client requests.
-            # (and charm tracing and logging TLS)
-            ca_cert_path.parent.mkdir(exist_ok=True, parents=True)
-            ca_cert_path.write_text(self.server_cert.ca_cert)  # pyright: ignore
-        else:
+        # Repeat for the charm container. We need it there for loki client requests.
+        # (and charm tracing and logging TLS)
+        ca_cert_path.parent.mkdir(exist_ok=True, parents=True)
+        ca_cert_path.write_text(self.server_cert.ca_cert)  # pyright: ignore
+
+    def _remove_cert_files(self):
+        ca_cert_path = Path(self._ca_cert_path)
+        try:
             self._loki_container.remove_path(CERT_FILE, recursive=True)
             self._loki_container.remove_path(KEY_FILE, recursive=True)
             self._loki_container.remove_path(ca_cert_path, recursive=True)
+        except ConnectionError:
+            logger.error("Could not remove cert files. Pebble refused connection. Shutting down?")
+            return
 
-            # Repeat for the charm container.
-            ca_cert_path.unlink(missing_ok=True)
+        # Repeat for the charm container.
+        ca_cert_path.unlink(missing_ok=True)
 
-        self._loki_container.exec(["update-ca-certificates", "--fresh"]).wait()
-        subprocess.run(["update-ca-certificates", "--fresh"])
+    def _update_ca_certificates(self):
+        try:
+            self._loki_container.exec(["update-ca-certificates", "--fresh"]).wait()
+            subprocess.run(["update-ca-certificates", "--fresh"])
+        except (ConnectionError, ExecError) as e:
+            logger.error("Could not run update-ca-certificates in workload container. %s", e)
+        except subprocess.SubprocessError as e:
+            logger.error("Could not run update-ca-certificates in charm container. %s", e)
 
     def _alerting_config(self) -> str:
         """Construct Loki altering configuration.
@@ -779,7 +798,14 @@ class LokiOperatorCharm(CharmBase):
         """
         if not self._loki_container.can_connect():
             return None
-        version_output, _ = self._loki_container.exec(["/usr/bin/loki", "-version"]).wait_output()
+        try:
+            version_output, _ = self._loki_container.exec(
+                ["/usr/bin/loki", "-version"]
+            ).wait_output()
+        except ExecError as e:
+            logger.error("Error retrieving Loki version: %s", e)
+            return None
+
         # Output looks like this:
         # loki, version 2.4.1 (branch: HEAD, ...
         result = re.search(r"version (\d*\.\d*\.\d*)", version_output)

--- a/src/charm.py
+++ b/src/charm.py
@@ -566,10 +566,10 @@ class LokiOperatorCharm(CharmBase):
         return False
 
     def _update_cert(self):
+        self._remove_cert_files()
+
         if self.server_cert.available:
             self._push_cert_files()
-        else:
-            self._remove_cert_files()
 
         self._update_ca_certificates()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -566,6 +566,9 @@ class LokiOperatorCharm(CharmBase):
         return False
 
     def _update_cert(self):
+        # If Pebble is not ready, we do not proceed.
+        # This code will end up running anyway when Pebble is ready, because
+        # it will eventually be called from the `_configure()` method.
         if not self._loki_container.can_connect():
             return
 

--- a/tests/integration/log-forwarder-tester/charmcraft.yaml
+++ b/tests/integration/log-forwarder-tester/charmcraft.yaml
@@ -13,3 +13,13 @@ parts:
   charm:
     build-packages:
       - git
+
+    charm-binary-python-packages:
+      # For v2.tls_certificates
+      - cryptography
+      - jsonschema
+
+      # For v1.alertmanager_dispatch & v1.tracing
+      - pydantic>=2
+
+      - cosl

--- a/tests/integration/log-proxy-tester/charmcraft.yaml
+++ b/tests/integration/log-proxy-tester/charmcraft.yaml
@@ -13,3 +13,13 @@ parts:
   charm:
     build-packages:
       - git
+
+    charm-binary-python-packages:
+      # For v2.tls_certificates
+      - cryptography
+      - jsonschema
+
+      # For v1.alertmanager_dispatch & v1.tracing
+      - pydantic>=2
+
+      - cosl

--- a/tests/integration/loki-tester/charmcraft.yaml
+++ b/tests/integration/loki-tester/charmcraft.yaml
@@ -8,3 +8,12 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+parts:
+  charm:
+    charm-binary-python-packages:
+      # For v2.tls_certificates
+      - cryptography
+      - jsonschema
+
+      # For v1.alertmanager_dispatch & v1.tracing
+      - pydantic>=2

--- a/tests/integration/loki-tester/charmcraft.yaml
+++ b/tests/integration/loki-tester/charmcraft.yaml
@@ -17,3 +17,5 @@ parts:
 
       # For v1.alertmanager_dispatch & v1.tracing
       - pydantic>=2
+
+      - cosl

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -23,3 +23,6 @@ class FakeProcessVersionCheck:
 
     def wait_output(self):
         return ("v0.1.0", "")
+
+    def wait(self):
+        return ("v0.1.0", "")

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 # codespell pinned cause version 2.3.0 mistakenly considers joined words such as "assertIn" invalid
@@ -46,7 +46,7 @@ deps =
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR add some missing `can_connect()` guards in loki_push_api lib, and improves exception handling in Loki charm.

See #390



## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

- Run the test suite (unit, scenario, integration) and verify everything is green.
- Alternatively you can manually:
  - `juju add-model apps`
  - `juju deploy grafana-agent-k8s agent --channel latest/edge`
  - `juju deploy sdcore-udr-k8s --channel 1.5/edge`
  - Copy the new version of the lib into the sdcore-udr-k8s repo
  - Sync repo with running charm: `jhack utils sync sdcore-udr-k8s/0`
  - Relate both charms: `juju relate sdcore-udr-k8s:logging agent:logging-provider`
  - Check there are no errors like [these ones ](https://github.com/canonical/loki-k8s-operator/issues/390) in juju debug-log like



