### PR TITLE
 Refactor loki to use new `KubernetesComputeResourcesPatch` with `pull` status

### DIFF
--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -2,6 +2,7 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 import scenario
+
 from charm import LokiOperatorCharm
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,11 +11,12 @@ from unittest.mock import Mock, PropertyMock, patch
 from urllib.error import HTTPError, URLError
 
 import yaml
-from charm import LOKI_CONFIG as LOKI_CONFIG_PATH
-from charm import LokiOperatorCharm
 from helpers import FakeProcessVersionCheck, k8s_resource_multipatch
 from ops.model import ActiveStatus, BlockedStatus, Container, MaintenanceStatus
 from ops.testing import Harness
+
+from charm import LOKI_CONFIG as LOKI_CONFIG_PATH
+from charm import LokiOperatorCharm
 
 METADATA = {
     "model": "consumer-model",


### PR DESCRIPTION
Refactor `loki` to use the new `KubernetesComputeResourcesPatch` where we can query `is_ready` in `collect-status` to wait for the patch to complete. For errors, they will be retried until successful or raise an exception if its a non-recoverable error, like negative limit values.

## Context
Used to verify https://github.com/canonical/observability-libs/pull/107
