### PR TITLE
Enable structured_metadata

### DIFF
--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -26,7 +26,7 @@ You can then observe the library's custom event and make use of the key and cert
 self.framework.observe(self.cert_handler.on.cert_changed, self._on_server_cert_changed)
 
 container.push(keypath, self.cert_handler.private_key)
-container.push(certpath, self.cert_handler.servert_cert)
+container.push(certpath, self.cert_handler.server_cert)
 ```
 
 Since this library uses [Juju Secrets](https://juju.is/docs/juju/secret) it requires Juju >= 3.0.3.
@@ -59,7 +59,7 @@ except ImportError as e:
 import logging
 
 from ops.charm import CharmBase
-from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents, StoredState
 from ops.jujuversion import JujuVersion
 from ops.model import Relation, Secret, SecretNotFoundError
 
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 1
-LIBPATCH = 11
+LIBPATCH = 12
 
 VAULT_SECRET_LABEL = "cert-handler-private-vault"
 
@@ -273,6 +273,7 @@ class CertHandler(Object):
     """A wrapper for the requirer side of the TLS Certificates charm library."""
 
     on = CertHandlerEvents()  # pyright: ignore
+    _stored = StoredState()
 
     def __init__(
         self,
@@ -283,6 +284,7 @@ class CertHandler(Object):
         peer_relation_name: str = "peers",
         cert_subject: Optional[str] = None,
         sans: Optional[List[str]] = None,
+        refresh_events: Optional[List[BoundEvent]] = None,
     ):
         """CertHandler is used to wrap TLS Certificates management operations for charms.
 
@@ -299,8 +301,17 @@ class CertHandler(Object):
                 Must match metadata.yaml.
             cert_subject: Custom subject. Name collisions are under the caller's responsibility.
             sans: DNS names. If none are given, use FQDN.
+            refresh_events: an optional list of bound events which
+                will be observed to replace the current CSR with a new one
+                if there are changes in the CSR's DNS SANs or IP SANs.
+                Then, subsequently, replace its corresponding certificate with a new one.
         """
         super().__init__(charm, key)
+        # use StoredState to store the hash of the CSR
+        # to potentially trigger a CSR renewal on `refresh_events`
+        self._stored.set_default(
+            csr_hash=None,
+        )
         self.charm = charm
 
         # We need to sanitize the unit name, otherwise route53 complains:
@@ -354,6 +365,15 @@ class CertHandler(Object):
             self.charm.on.upgrade_charm,  # pyright: ignore
             self._on_upgrade_charm,
         )
+
+        if refresh_events:
+            for ev in refresh_events:
+                self.framework.observe(ev, self._on_refresh_event)
+
+    def _on_refresh_event(self, _):
+        """Replace the latest current CSR with a new one if there are any SANs changes."""
+        if self._stored.csr_hash != self._csr_hash:
+            self._generate_csr(renew=True)
 
     def _on_upgrade_charm(self, _):
         has_privkey = self.vault.get_value("private-key")
@@ -420,6 +440,20 @@ class CertHandler(Object):
         return True
 
     @property
+    def _csr_hash(self) -> int:
+        """A hash of the config that constructs the CSR.
+
+        Only include here the config options that, should they change, should trigger a renewal of
+        the CSR.
+        """
+        return hash(
+            (
+                tuple(self.sans_dns),
+                tuple(self.sans_ip),
+            )
+        )
+
+    @property
     def available(self) -> bool:
         """Return True if all certs are available in relation data; False otherwise."""
         return (
@@ -483,6 +517,8 @@ class CertHandler(Object):
                     self.sans_ip,
                 )
                 self.certificates.request_certificate_creation(certificate_signing_request=csr)
+
+            self._stored.csr_hash = self._csr_hash
 
         if clear_cert:
             self.vault.clear()

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -172,14 +172,64 @@ needs to be replaced with:
 provide an *absolute* path to the certificate file instead.
 """
 
+
+def _remove_stale_otel_sdk_packages():
+    """Hack to remove stale opentelemetry sdk packages from the charm's python venv.
+
+    See https://github.com/canonical/grafana-agent-operator/issues/146 and
+    https://bugs.launchpad.net/juju/+bug/2058335 for more context. This patch can be removed after
+    this juju issue is resolved and sufficient time has passed to expect most users of this library
+    have migrated to the patched version of juju.  When this patch is removed, un-ignore rule E402 for this file in the pyproject.toml (see setting
+    [tool.ruff.lint.per-file-ignores] in pyproject.toml).
+
+    This only has an effect if executed on an upgrade-charm event.
+    """
+    # all imports are local to keep this function standalone, side-effect-free, and easy to revert later
+    import os
+
+    if os.getenv("JUJU_DISPATCH_PATH") != "hooks/upgrade-charm":
+        return
+
+    import logging
+    import shutil
+    from collections import defaultdict
+
+    from importlib_metadata import distributions
+
+    otel_logger = logging.getLogger("charm_tracing_otel_patcher")
+    otel_logger.debug("Applying _remove_stale_otel_sdk_packages patch on charm upgrade")
+    # group by name all distributions starting with "opentelemetry_"
+    otel_distributions = defaultdict(list)
+    for distribution in distributions():
+        name = distribution._normalized_name  # type: ignore
+        if name.startswith("opentelemetry_"):
+            otel_distributions[name].append(distribution)
+
+    otel_logger.debug(f"Found {len(otel_distributions)} opentelemetry distributions")
+
+    # If we have multiple distributions with the same name, remove any that have 0 associated files
+    for name, distributions_ in otel_distributions.items():
+        if len(distributions_) <= 1:
+            continue
+
+        otel_logger.debug(f"Package {name} has multiple ({len(distributions_)}) distributions.")
+        for distribution in distributions_:
+            if not distribution.files:  # Not None or empty list
+                path = distribution._path  # type: ignore
+                otel_logger.info(f"Removing empty distribution of {name} at {path}.")
+                shutil.rmtree(path)
+
+    otel_logger.debug("Successfully applied _remove_stale_otel_sdk_packages patch. ")
+
+
+_remove_stale_otel_sdk_packages()
+
 import functools
 import inspect
 import logging
 import os
-import shutil
 from contextlib import contextmanager
 from contextvars import Context, ContextVar, copy_context
-from importlib.metadata import distributions
 from pathlib import Path
 from typing import (
     Any,
@@ -199,14 +249,15 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace import INVALID_SPAN, Tracer
-from opentelemetry.trace import get_current_span as otlp_get_current_span
 from opentelemetry.trace import (
+    INVALID_SPAN,
+    Tracer,
     get_tracer,
     get_tracer_provider,
     set_span_in_context,
     set_tracer_provider,
 )
+from opentelemetry.trace import get_current_span as otlp_get_current_span
 from ops.charm import CharmBase
 from ops.framework import Framework
 
@@ -219,7 +270,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 13
+LIBPATCH = 15
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 
@@ -228,7 +279,6 @@ dev_logger = logging.getLogger("tracing-dev")
 
 # set this to 0 if you are debugging/developing this library source
 dev_logger.setLevel(logging.CRITICAL)
-
 
 _CharmType = Type[CharmBase]  # the type CharmBase and any subclass thereof
 _C = TypeVar("_C", bound=_CharmType)
@@ -281,9 +331,22 @@ def _get_tracer() -> Optional[Tracer]:
     try:
         return tracer.get()
     except LookupError:
+        # fallback: this course-corrects for a user error where charm_tracing symbols are imported
+        # from different paths (typically charms.tempo_k8s... and lib.charms.tempo_k8s...)
         try:
             ctx: Context = copy_context()
             if context_tracer := _get_tracer_from_context(ctx):
+                logger.warning(
+                    "Tracer not found in `tracer` context var. "
+                    "Verify that you're importing all `charm_tracing` symbols from the same module path. \n"
+                    "For example, DO"
+                    ": `from charms.lib...charm_tracing import foo, bar`. \n"
+                    "DONT: \n"
+                    " \t - `from charms.lib...charm_tracing import foo` \n"
+                    " \t - `from lib...charm_tracing import bar` \n"
+                    "For more info: https://python-notes.curiousefficiency.org/en/latest/python"
+                    "_concepts/import_traps.html#the-double-import-trap"
+                )
                 return context_tracer.get()
             else:
                 return None
@@ -361,30 +424,6 @@ def _get_server_cert(
     return server_cert
 
 
-def _remove_stale_otel_sdk_packages():
-    """Hack to remove stale opentelemetry sdk packages from the charm's python venv.
-
-    See https://github.com/canonical/grafana-agent-operator/issues/146 and
-    https://bugs.launchpad.net/juju/+bug/2058335 for more context. This patch can be removed after
-    this juju issue is resolved and sufficient time has passed to expect most users of this library
-    have migrated to the patched version of juju.
-
-    This only does something if executed on an upgrade-charm event.
-    """
-    if os.getenv("JUJU_DISPATCH_PATH") == "hooks/upgrade-charm":
-        logger.debug("Executing _remove_stale_otel_sdk_packages patch on charm upgrade")
-        # Find any opentelemetry_sdk distributions
-        otel_sdk_distributions = list(distributions(name="opentelemetry_sdk"))
-        # If there is more than 1, inspect each and if it has 0 entrypoints, infer that it is stale
-        if len(otel_sdk_distributions) > 1:
-            for distribution in otel_sdk_distributions:
-                if len(distribution.entry_points) == 0:
-                    # Distribution appears to be empty. Remove it
-                    path = distribution._path  # type: ignore
-                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {path}")
-                    shutil.rmtree(path)
-
-
 def _setup_root_span_initializer(
     charm_type: _CharmType,
     tracing_endpoint_attr: str,
@@ -420,7 +459,6 @@ def _setup_root_span_initializer(
         # apply hacky patch to remove stale opentelemetry sdk packages on upgrade-charm.
         # it could be trouble if someone ever decides to implement their own tracer parallel to
         # ours and before the charm has inited. We assume they won't.
-        _remove_stale_otel_sdk_packages()
         resource = Resource.create(
             attributes={
                 "service.name": _service_name,

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -318,7 +318,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 18
+LIBPATCH = 19
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -736,16 +736,16 @@ def calculate_expiry_notification_time(
     """
     if provider_recommended_notification_time is not None:
         provider_recommended_notification_time = abs(provider_recommended_notification_time)
-        provider_recommendation_time_delta = (
-            expiry_time - timedelta(hours=provider_recommended_notification_time)
+        provider_recommendation_time_delta = expiry_time - timedelta(
+            hours=provider_recommended_notification_time
         )
         if validity_start_time < provider_recommendation_time_delta:
             return provider_recommendation_time_delta
 
     if requirer_recommended_notification_time is not None:
         requirer_recommended_notification_time = abs(requirer_recommended_notification_time)
-        requirer_recommendation_time_delta = (
-            expiry_time - timedelta(hours=requirer_recommended_notification_time)
+        requirer_recommendation_time_delta = expiry_time - timedelta(
+            hours=requirer_recommended_notification_time
         )
         if validity_start_time < requirer_recommendation_time_delta:
             return requirer_recommendation_time_delta
@@ -1449,18 +1449,33 @@ class TLSCertificatesProvidesV3(Object):
         Returns:
             None
         """
-        provider_certificates = self.get_provider_certificates(relation_id)
-        requirer_csrs = self.get_requirer_csrs(relation_id)
+        provider_certificates = self.get_unsolicited_certificates(
+            relation_id=relation_id
+        )
+        for provider_certificate in provider_certificates:
+            self.on.certificate_revocation_request.emit(
+                certificate=provider_certificate.certificate,
+                certificate_signing_request=provider_certificate.csr,
+                ca=provider_certificate.ca,
+                chain=provider_certificate.chain,
+            )
+            self.remove_certificate(certificate=provider_certificate.certificate)
+
+    def get_unsolicited_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return provider certificates for which no certificate requests exists.
+
+        Those certificates should be revoked.
+        """
+        unsolicited_certificates: List[ProviderCertificate] = []
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        requirer_csrs = self.get_requirer_csrs(relation_id=relation_id)
         list_of_csrs = [csr.csr for csr in requirer_csrs]
         for certificate in provider_certificates:
             if certificate.csr not in list_of_csrs:
-                self.on.certificate_revocation_request.emit(
-                    certificate=certificate.certificate,
-                    certificate_signing_request=certificate.csr,
-                    ca=certificate.ca,
-                    chain=certificate.chain,
-                )
-                self.remove_certificate(certificate=certificate.certificate)
+                unsolicited_certificates.append(certificate)
+        return unsolicited_certificates
 
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
@@ -1878,8 +1893,7 @@ class TLSCertificatesRequiresV3(Object):
                             "Removing secret with label %s",
                             f"{LIBID}-{csr_in_sha256_hex}",
                         )
-                        secret = self.model.get_secret(
-                            label=f"{LIBID}-{csr_in_sha256_hex}")
+                        secret = self.model.get_secret(label=f"{LIBID}-{csr_in_sha256_hex}")
                         secret.remove_all_revisions()
                     self.on.certificate_invalidated.emit(
                         reason="revoked",

--- a/tests/integration/test_boltdb_v11_to_tsdb_v12_migration.py
+++ b/tests/integration/test_boltdb_v11_to_tsdb_v12_migration.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 V11_APP_NAME = f'v11-{METADATA["name"]}'
 V12_APP_NAME = f'v12-{METADATA["name"]}'
+V13_APP_NAME = f'v13-{METADATA["name"]}'
+LOKI_UPGRADED = "loki-v11-v12-v13"
 
 resources = {
     "loki-image": METADATA["resources"]["loki-image"]["upstream-source"],
@@ -35,27 +37,30 @@ async def test_setup_env(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_from_charmhub_v11_and_upgrade_to_v12_locally(ops_test: OpsTest, loki_charm):
-    """Deploy from Charmhub (v11 schema) and upgrade to v12 locally."""
-    await deploy_charm_from_charmhub_v11(ops_test, V11_APP_NAME)
-    await upgrade_charm_with_local_charm_v12(ops_test, V11_APP_NAME, loki_charm)
-    await verify_upgrade_success(ops_test, V11_APP_NAME, False)
+async def test_deploy_from_charmhub_v11_and_upgrade_to_v12_to_v13(ops_test: OpsTest, loki_charm):
+    """Deploy from Charmhub (v11 schema) and upgrade to v12."""
+    await deploy_charm_from_charmhub_v11(ops_test, LOKI_UPGRADED)
+    await upgrade_charm_from_charmhub_v12(ops_test, LOKI_UPGRADED, loki_charm)
+    await verify_upgrade_success(ops_test, LOKI_UPGRADED, False, "v12")
 
     # Here we upgrade again to ensure config is persisted and won't be overwritten with any weird values
-    await upgrade_charm_with_local_charm_v12(ops_test, V11_APP_NAME, loki_charm)
-    await verify_upgrade_success(ops_test, V11_APP_NAME, False)
+    await upgrade_charm_from_charmhub_v12(ops_test, LOKI_UPGRADED, loki_charm)
+    await verify_upgrade_success(ops_test, LOKI_UPGRADED, False, "v12")
+
+    await upgrade_charm_with_local_charm_v13(ops_test, LOKI_UPGRADED, loki_charm)
+    await verify_upgrade_success(ops_test, LOKI_UPGRADED, False, "v13")
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_and_upgrade_v12_locally(ops_test: OpsTest, loki_charm):
-    """Deploy from a local charm (v12 schema) and upgrade locally."""
-    await deploy_local_charm_v12(ops_test, V12_APP_NAME, loki_charm)
-    await upgrade_charm_with_local_charm_v12(ops_test, V12_APP_NAME, loki_charm)
-    await verify_upgrade_success(ops_test, V12_APP_NAME, True)
+async def test_deploy_and_upgrade_v13_locally(ops_test: OpsTest, loki_charm):
+    """Deploy from a local charm (v13 schema) and upgrade locally."""
+    await deploy_local_charm_v13(ops_test, V13_APP_NAME, loki_charm)
+    await upgrade_charm_with_local_charm_v13(ops_test, V13_APP_NAME, loki_charm)
+    await verify_upgrade_success(ops_test, V13_APP_NAME, True, "v13")
 
     # Here we upgrade again to ensure config is persisted and won't be overwritten with any weird values
-    await upgrade_charm_with_local_charm_v12(ops_test, V12_APP_NAME, loki_charm)
-    await verify_upgrade_success(ops_test, V12_APP_NAME, True)
+    await upgrade_charm_with_local_charm_v13(ops_test, V13_APP_NAME, loki_charm)
+    await verify_upgrade_success(ops_test, V13_APP_NAME, True, "v13")
 
 
 async def deploy_charm_from_charmhub_v11(ops_test: OpsTest, app_name):
@@ -71,7 +76,14 @@ async def deploy_charm_from_charmhub_v11(ops_test: OpsTest, app_name):
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
 
-async def deploy_local_charm_v12(ops_test: OpsTest, app_name, loki_charm):
+async def upgrade_charm_from_charmhub_v12(ops_test: OpsTest, app_name, loki_charm):
+    """Upgrade the deployed charm with the local charm."""
+    logger.debug("Upgrading deployed charm with local charm %s", loki_charm)
+    await ops_test.model.applications[app_name].refresh(channel="stable", revision=151)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+
+
+async def deploy_local_charm_v13(ops_test: OpsTest, app_name, loki_charm):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
     await ops_test.model.deploy(
@@ -80,18 +92,21 @@ async def deploy_local_charm_v12(ops_test: OpsTest, app_name, loki_charm):
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
 
-async def upgrade_charm_with_local_charm_v12(ops_test: OpsTest, app_name, loki_charm):
+async def upgrade_charm_with_local_charm_v13(ops_test: OpsTest, app_name, loki_charm):
     """Upgrade the deployed charm with the local charm."""
     logger.debug("Upgrading deployed charm with local charm %s", loki_charm)
     await ops_test.model.applications[app_name].refresh(path=loki_charm, resources=resources)
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
 
-async def verify_upgrade_success(ops_test: OpsTest, app_name, is_fresh_installation: bool):
+async def verify_upgrade_success(
+    ops_test: OpsTest, app_name, is_fresh_installation: bool, version: str = "v13"
+):
     """Verify that the upgrade was successful."""
+    positions = {"v11": 0, "v12": 1, "v13": 2}
     assert await is_loki_up(ops_test, app_name)
     post_upgrade_config = await loki_config(ops_test, app_name)
-    tsdb_schema_configs = post_upgrade_config["schema_config"]["configs"][1]
+    tsdb_schema_configs = post_upgrade_config["schema_config"]["configs"][positions[version]]
 
     expected_from = (
         (datetime.date.today()).strftime("%Y-%m-%d")
@@ -99,5 +114,5 @@ async def verify_upgrade_success(ops_test: OpsTest, app_name, is_fresh_installat
         else (datetime.date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
     )
     assert tsdb_schema_configs["store"] == "tsdb"
-    assert tsdb_schema_configs["schema"] == "v12"
+    assert tsdb_schema_configs["schema"] == version
     assert tsdb_schema_configs["from"] == expected_from

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -2,6 +2,7 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 import scenario
+
 from charm import LokiOperatorCharm
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,11 +11,12 @@ from unittest.mock import Mock, PropertyMock, patch
 from urllib.error import HTTPError, URLError
 
 import yaml
-from charm import LOKI_CONFIG as LOKI_CONFIG_PATH
-from charm import LokiOperatorCharm
 from helpers import FakeProcessVersionCheck, k8s_resource_multipatch
 from ops.model import ActiveStatus, BlockedStatus, Container, MaintenanceStatus
 from ops.testing import Harness
+
+from charm import LOKI_CONFIG as LOKI_CONFIG_PATH
+from charm import LokiOperatorCharm
 
 METADATA = {
     "model": "consumer-model",


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

In order to avoid [high cardinality in Loki](https://discourse.charmhub.io/t/solving-high-cardinality-labels-in-loki/15426) this PR enables `structured_metadata`

Partially solves https://github.com/canonical/loki-k8s-operator/issues/439 

This PR goes in tandem with: https://github.com/canonical/grafana-agent-operator/pull/180


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run integration tests

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

Now the default schema version is `v13`
