### PR TITLE
Chore: Pin Scenario to version 6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ description = Scenario tests
 deps =
     pytest
     pydantic>=2
-    ops-scenario
+    ops-scenario==6.1.7
     ops
     opentelemetry-exporter-otlp-proto-http==1.21.0  # PYDEPS for tracing
     importlib-metadata==6.0.0  # PYDEPS for tracing


### PR DESCRIPTION
## Issue
With the release of Scenario v7 there are a lot of breaking changes like [ExecOutput is now Exec](https://github.com/canonical/ops-scenario/blob/29a50b75893f199d83713d675588bdbb2efccf13/UPGRADING.md?plain=1#L292). Scenario is pinned to latest release of major version 6 (6.1.7).
