### PR TITLE
Initial Commit

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -1,0 +1,16 @@
+command:
+  self-tests-health:
+    exec: juju ssh loki-k8s/0 /charm/bin/pebble health
+    exit-status: 0
+    stdout:
+      - healthy
+  relation-cluster:
+    exec: juju status --relations | grep grafana_datasource | grep regular
+    exit-status: 0
+    stdout:
+      - grafana-source
+  charm-exit-codes:
+    exec: kubectl describe -n welcome-k8s pod loki-0 | grep -A 15 "Containers:" | grep -A 15 "charm:" | grep -A 3 "State:"
+    exit-status: 0
+    stdout:
+      - Running


### PR DESCRIPTION
## Issue
As part of [OPENG-2677](https://warthogs.atlassian.net/browse/OPENG-2677), we want to _Investigate goss to see how much of the cos doctor capacities we could possibly fulfil with goss_. The [OB041 - Juju Doctor (Pebble vs. Goss)](https://docs.google.com/document/d/10EhRTWHAm7Oyog6j4iFkaAOP6tJLlqS8tKnS5AoCk4w/edit) doc was created and highlights a sample, external Goss architecture with charm health checks via Pebble.

## Solution
This PR aims to provide:

1. A `goss.yaml` in the root of the charm that is used with the [Goss binary](https://goss.readthedocs.io/en/stable/installation/) on the operator's host to provide predefined tests, specific to the charm repo. 
2. The charm author is expected to add necessary [Pebble health checks](https://juju.is/docs/sdk/interact-with-pebble#heading--perform-health-checks-on-the-workload-container) in the `charm.py` file for any necessary, internal checks.

This architecture is generic and can be applied to any charm.

## Context
* Internal tests are expected to be configured using Pebble health checks added to the Pebble layer. The Pebble binary offers two commands:
  * `health` -> Returns `healthy` if all checks pass
  * `checks` -> Returns a list of passing and failing checks
* External tests are expected to be configured in the `goss.yaml` file in the root of the charm repo which (potentially) has access to the host's `juju` and `k8s` context.
  * Therefore, we can run tests like `juju status --relations ...` and `kubectl describe ...`.

## Testing Instructions
1. Install the Goss binary on your host with `curl -fsSL https://goss.rocks/install | sh`
2. Deploy the charm
```
charmcraft pack
juju deploy ./*.charm loki-k8s --resource loki-image=docker.io/ubuntu/loki:2-22.04 --resource node-exporter-image=docker.io/prom/node-exporter:v1.7.0 --trust
```
3. Test with Goss using `goss v -f tap`

Expected results:
```
1..6
ok 1 - Command: charm-exit-codes: exit-status: matches expectation: 0
ok 2 - Command: charm-exit-codes: stdout: matches expectation: ["Running"]
ok 3 - Command: relation-cluster: exit-status: matches expectation: 0
ok 4 - Command: relation-cluster: stdout: matches expectation: ["grafana-source"]
ok 5 - Command: self-tests-health: exit-status: matches expectation: 0
ok 6 - Command: self-tests-health: stdout: matches expectation: ["healthy"]
```
