### PR TITLE
Update build-promtail-release.yaml

### DIFF
--- a/.github/workflows/build-promtail-release.yaml
+++ b/.github/workflows/build-promtail-release.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 'stable'
       - name: Install systemd dependencies
         run: |
           sudo apt-get update
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 'stable'
       - name: Build Promtail
         # We run the make-based build with CGO_ENABLED=0
         # because we want statically-linked binaries and


### PR DESCRIPTION
Let's use stable to avoid these kind of errors:
https://github.com/canonical/loki-k8s-operator/actions/runs/10815373052/job/30004121626#step:7:11
```
/home/runner/work/loki-k8s-operator/loki-k8s-operator/loki-upstream/go.mod:3: invalid go version '1.21.8': must match format 1.23
make: *** [Makefile:251: clients/cmd/promtail/promtail] Error 1
```

We install go 1.19 and Loki requires [1.21.8](https://github.com/grafana/loki/blob/main/go.mod#L3)