### PR TITLE
add pipeline_stage to remove `filename` label

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -561,18 +561,19 @@ PROMTAIL_BASE_URL = "https://github.com/canonical/loki-k8s-operator/releases/dow
 # To update Promtail version you only need to change the PROMTAIL_VERSION and
 # update all sha256 sums in PROMTAIL_BINARIES. To support a new architecture
 # you only need to add a new key value pair for the architecture in PROMTAIL_BINARIES.
-PROMTAIL_VERSION = "v2.9.7"
+
+PROMTAIL_VERSION = "v2.9.9"
 PROMTAIL_ARM_BINARY = {
     "filename": "promtail-static-arm64",
-    "zipsha": "c083fdb45e5c794103f974eeb426489b4142438d9e10d0ae272b2aff886e249b",
-    "binsha": "4cd055c477a301c0bdfdbcea514e6e93f6df5d57425ce10ffc77f3e16fec1ddf",
+    "zipsha": "80ac879c16b8bf926bb2feebc69d4f248c266aea235c5cd1c6a8a9eb751c5633",
+    "binsha": "550a8b5cbbde3881dacf9d58700a3311fea4996f43cff1dfb60b291a94db8fbd",
 }
 
 PROMTAIL_BINARIES = {
     "amd64": {
         "filename": "promtail-static-amd64",
-        "zipsha": "6873cbdabf23062aeefed6de5f00ff382710332af3ab90a48c253ea17e08f465",
-        "binsha": "28da9b99f81296fe297831f3bc9d92aea43b4a92826b8ff04ba433b8cb92fb50",
+        "zipsha": "41c195e0a0d6ac04a1c0d6bb6fdb3892b9608f0c80059e35340dfc7adb9d65d2",
+        "binsha": "cc1d3bdb2999c2c0c11b9e3ec32eaea10507c0a3726d77318bde3af5cb4e6f00",
     },
     "arm64": PROMTAIL_ARM_BINARY,
     "aarch64": PROMTAIL_ARM_BINARY,

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -546,7 +546,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["cosl"]
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -2316,14 +2316,6 @@ class LogProxyConsumer(ConsumerBase):
             # we are not modifying it to avoid backwards compatibility issues.
             syslog_config = {
                 "job_name": "syslog",
-                "pipeline_stages": [
-                    {
-                        "structured_metadata": {"filename": "filename"},
-                    },
-                    {
-                        "labeldrop": ["filename"],
-                    },
-                ],
                 "syslog": {
                     "listen_address": f"127.0.0.1:{syslog_port}",
                     "label_structured_data": True,

--- a/tests/integration/test_applications_send_logs.py
+++ b/tests/integration/test_applications_send_logs.py
@@ -30,7 +30,7 @@ tester_resources = {
 # Proceed with care
 tester_apps = {
     "loki-tester": '{juju_application="loki-tester",level="debug"}',
-    "log-proxy-tester-file": '{juju_application="log-proxy-tester-file",filename=~".+"}',
+    "log-proxy-tester-file": '{juju_application="log-proxy-tester-file"} | filename=~".+"',
     "log-proxy-tester-syslog": '{juju_application="log-proxy-tester-syslog",job=~".+syslog"}',
 }
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR goes in tandem with https://github.com/canonical/grafana-agent-operator/pull/180


## Solution
<!-- A summary of the solution addressing the above issue -->

We add `pipeline_stages` to `promtail` configuration in order to remove `filename` label an add it as `structured_metadata`

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Deploy this bundle (update lib in `flog` and pack `loki`)

```yaml
bundle: kubernetes
applications:
  flog:
    charm: flog-k8s
    channel: latest/edge
    revision: 8
    resources:
      workload-image: 2
    scale: 1
    constraints: arch=amd64
  grafana:
    charm: grafana-k8s
    channel: latest/edge
    revision: 118
    resources:
      grafana-image: 70
      litestream-image: 45
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: local:loki-k8s-0
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 207
    resources:
      traefik-image: 160
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:ingress-per-unit
  - loki:ingress
- - grafana:ingress
  - traefik:traefik-route
- - grafana:grafana-source
  - loki:grafana-source
- - flog:log-proxy
  - loki:logging
```

Check in Grafana that `filename` is not a regular label but part of `structured_metadata`

![image](https://github.com/user-attachments/assets/08ce57e8-41f1-43b2-b52e-7194d93ab3ba)

![image](https://github.com/user-attachments/assets/be0d3a64-d890-4e8f-b62f-51a4634ed1ad)
