### PR TITLE
use loki_push_api v1

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -31,7 +31,7 @@ from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.loki_k8s.v0.charm_logging import log_charm
-from charms.loki_k8s.v0.loki_push_api import (
+from charms.loki_k8s.v1.loki_push_api import (
     LokiPushApiAlertRulesChanged,
     LokiPushApiProvider,
 )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Now we use loki_push_api v1.... 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

While working on https://github.com/canonical/loki-k8s-operator/pull/455 and https://github.com/canonical/grafana-agent-operator/pull/185 I've found that we were using v0 of the lib
