### PR TITLE
Provide a more detailed description for retention-period config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,10 +39,10 @@ options:
     default: 15
   retention-period:
     description: |
-      Sets a global retention period for log streams in Loki.
-      A value of 0 disables retention (default), logs will live forever if no duration is chosen.
-      This config maps directly to the `compactor.retention_enabled` configuration option, which is set to `false` when no retention period is defined.
-      The minimum retention period is 1 day. Specify the period in days. For example, to set a 48-day retention period, use `48`.
+      Sets a global retention period, in days, for log streams in Loki.
+      The minimum retention period is 1 day, and a value of 0 (default) means "infinity" (disables retention).
+      Loki will not be cleaning up logs if duration is set to 0.
+      This config maps directly to the loki `compactor.retention_enabled` configuration option, which is set to `false` when no retention period is defined.
       Specifying retention periods for individual streams is not currently supported.
 
       Ref: https://grafana.com/docs/loki/latest/operations/storage/retention/

--- a/config.yaml
+++ b/config.yaml
@@ -39,9 +39,12 @@ options:
     default: 15
   retention-period:
     description: |
-      Sets a global retention period for log streams in Loki. A value of 0 disables retention (default).
-      Minimum retention period is 1d.
-      Specify the period in days. For example, to set a 48-day retention period, use `48`.
+      Sets a global retention period for log streams in Loki.
+      A value of 0 disables retention (default), logs will live forever if no duration is chosen.
+      This config maps directly to the `compactor.retention_enabled` configuration option, which is set to `false` when no retention period is defined.
+      The minimum retention period is 1 day. Specify the period in days. For example, to set a 48-day retention period, use `48`.
       Specifying retention periods for individual streams is not currently supported.
+
+      Ref: https://grafana.com/docs/loki/latest/operations/storage/retention/
     type: int
     default: 0


### PR DESCRIPTION
## Description
This PR updates the `retention-period` config description to provide more detailed information about the default behavior and its relation to the `compactor.retention_enabled` setting. No functional changes.
