### PR TITLE
feat: disable-reporting juju config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,3 +48,13 @@ options:
       Ref: https://grafana.com/docs/loki/latest/operations/storage/retention/
     type: int
     default: 0
+  reporting-enabled:
+    description: |
+      When disabled, Loki will be configured to not send anonymous usage statistics to stats.grafana.org.
+      It is very helpful to the Grafana project, so please leave this enabled.
+      
+      When enabled, Loki will use its default values for analytics.
+      
+      Ref: https://grafana.com/docs/loki/latest/configure/#analytics
+    type: boolean
+    default: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cosl>=0.0.12
 # pinned to 2.16 as 2.17 breaks our unittests
-ops == 2.16
+ops
 kubernetes
 requests
 lightkube

--- a/src/charm.py
+++ b/src/charm.py
@@ -500,6 +500,7 @@ class LokiOperatorCharm(CharmBase):
             retention_period=int(self.config["retention-period"]),
             http_tls=self._tls_ready,
             tsdb_versions_migration_dates=self._tsdb_versions_migration_dates,
+            reporting_enabled=bool(self.config["reporting-enabled"]),
         ).build()
 
         # Add a layer so we can check if the service is running

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,7 +1,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops.testing import Context
 
 from charm import LokiOperatorCharm
 
@@ -25,4 +25,4 @@ def loki_charm():
 
 @pytest.fixture
 def context(loki_charm):
-    return scenario.Context(loki_charm)
+    return Context(loki_charm)

--- a/tests/scenario/test_config_reporting_enabled.py
+++ b/tests/scenario/test_config_reporting_enabled.py
@@ -1,0 +1,59 @@
+import yaml
+from ops.testing import Container, Exec, State, pebble
+
+containers = [
+    Container(
+        name="loki",
+        can_connect=True,
+        layers={
+            "loki": pebble.Layer(
+                {
+                    "services": {
+                        "loki": {"startup": "enabled"},
+                    },
+                }
+            ),
+        },
+        execs={Exec(["update-ca-certificates", "--fresh"], return_code=0)},
+    ),
+    Container(name="node-exporter", can_connect=True),
+]
+
+
+def test_reporting_enabled(context):
+    # GIVEN the "reporting_enabled" config option is set to True
+    state = State(leader=True, config={"reporting-enabled": True}, containers=containers)
+
+    # WHEN config-changed fires
+    out = context.run(context.on.config_changed(), state)
+
+    # THEN the config file is written WITHOUT the [analytics] section being rendered
+    simulated_pebble_filesystem = out.get_container("loki").get_filesystem(context)
+    grafana_config_path = simulated_pebble_filesystem / "etc/loki/loki-local-config.yaml"
+
+    with open(grafana_config_path, "r") as file:
+        config = yaml.safe_load(file)
+
+    assert "analytics" not in config
+
+
+def test_reporting_disabled(context):
+    # GIVEN the "reporting_enabled" config option is set to False
+    state = State(leader=True, config={"reporting-enabled": False}, containers=containers)
+
+    # WHEN config-changed fires
+    out = context.run(context.on.config_changed(), state)
+
+    # THEN the config file is written WITH the [analytics] section being rendered
+    simulated_pebble_filesystem = out.get_container("loki").get_filesystem(context)
+    grafana_config_path = simulated_pebble_filesystem / "etc/loki/loki-local-config.yaml"
+
+    with open(grafana_config_path, "r") as file:
+        config = yaml.safe_load(file)
+
+    assert "analytics" in config
+    assert not config["analytics"].get("reporting_enabled")
+
+    # AND the "loki" service is restarted
+    # TODO Does it make sense to check this if the charm under test's lifetime is only for the config-changed?
+    # TODO How to assert this?

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -459,17 +459,7 @@ class TestAlertRuleBlockedStatus(unittest.TestCase):
     def tearDown(self):
         self.mock_request.stop()
 
-    @patch("ops.testing._TestingModelBackend.network_get")
-    def _add_alerting_relation(self, mock_unit_ip):
-        fake_network = {
-            "bind-addresses": [
-                {
-                    "interface-name": "eth0",
-                    "addresses": [{"hostname": "loki-0", "value": "10.1.2.3"}],
-                }
-            ]
-        }
-        mock_unit_ip.return_value = fake_network
+    def _add_alerting_relation(self):
         rel_id = self.harness.add_relation("logging", "tester")
         self.harness.add_relation_unit(rel_id, "tester/0")
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -4,7 +4,6 @@
 import json
 import textwrap
 import unittest
-from unittest.mock import patch
 
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
 from ops.charm import CharmBase
@@ -122,17 +121,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
         expected_value = {"url": endpoint}
         self.assertEqual(expected_value, self.harness.charm.loki_provider._endpoint(url))
 
-    @patch("ops.testing._TestingModelBackend.network_get")
-    def test__on_logging_relation_changed(self, mock_unit_ip):
-        fake_network = {
-            "bind-addresses": [
-                {
-                    "interface-name": "eth0",
-                    "addresses": [{"hostname": "loki-0", "value": "10.1.2.3"}],
-                }
-            ]
-        }
-        mock_unit_ip.return_value = fake_network
+    def test__on_logging_relation_changed(self):
         rel_id = self.harness.add_relation("logging", "promtail")
         self.harness.add_relation_unit(rel_id, "promtail/0")
 
@@ -141,17 +130,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
         )
         self.assertEqual(len(self.harness.charm._stored.events), 1)
 
-    @patch("ops.testing._TestingModelBackend.network_get")
-    def test__on_logging_relation_created_and_broken(self, mock_unit_ip):
-        fake_network = {
-            "bind-addresses": [
-                {
-                    "interface-name": "eth0",
-                    "addresses": [{"hostname": "loki-0", "value": "10.1.2.3"}],
-                }
-            ]
-        }
-        mock_unit_ip.return_value = fake_network
+    def test__on_logging_relation_created_and_broken(self):
         rel_id = self.harness.add_relation("logging", "promtail")
         self.harness.add_relation_unit(rel_id, "promtail/0")
 
@@ -163,17 +142,7 @@ class TestLokiPushApiProvider(unittest.TestCase):
         self.harness.remove_relation(rel_id)
         self.assertEqual(len(self.harness.charm._stored.events), 3)
 
-    @patch("ops.testing._TestingModelBackend.network_get")
-    def test_alerts(self, mock_unit_ip):
-        fake_network = {
-            "bind-addresses": [
-                {
-                    "interface-name": "eth0",
-                    "addresses": [{"hostname": "loki-0", "value": "10.1.2.3"}],
-                }
-            ]
-        }
-        mock_unit_ip.return_value = fake_network
+    def test_alerts(self):
         rel_id = self.harness.add_relation("logging", "consumer")
         self.harness.update_relation_data(
             rel_id,

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands =
 description = Scenario tests
 deps =
     pytest
-    ops-scenario==6.1.7
+    ops[testing]
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Some users do not want to send anonymous usage statistics to `stats.grafana.org`. For example, in an air-gapped environment this may cause excess logs due to the endpoint being unreachable.

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Adding a config option
Add a juju config option to the loki charm. By default the config will send usage statistics and will not write to the config file. Only if the `reporting-enabled` option is set to `false`, then we write to the [analytics block](https://grafana.com/docs/loki/latest/configure/#analytics) with `reporting_enabled=false` 

2. Add and fix tests
In an attempt to add scenario tests for testing this config option, the pin for ops=2.16 was removed and technical debt was removed to be compatible with the new ops.testing Scenario 7 syntax.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Since we want to contribute to upstream open-source, we leave the default option as reporting enabled.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

_Note: Deploying `--config reporting-enabled=true` is functionally equivalent to not supplying a config._ 
1. Pack the charm
`charmcraft pack`

### Deploy Loki default
4. Deploy `loki` (reporting enabled by default)
```
juju deploy ./*.charm loki --resource loki-image=docker.io/ubuntu/loki:2-22.04 --resource node-exporter-image=docker.io/prom/node-exporter:v1.7.0 --trust
juju ssh --container loki loki/0 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> null
```
5. Toggle the reporting config
```
juju config loki reporting-enabled=false
juju ssh --container loki loki/0 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> reporting_enabled: false
```
6. Scale the application up
``` 
juju add-unit loki -n 1
jssh --container loki loki/1 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> reporting_enabled: false
```
7. Toggle the config
``` 
juju config loki reporting-enabled=true
jssh --container loki loki/1 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> null
```

### Deploy Loki with reporting disabled
2. Deploy `loki-off` (reporting disabled)
```
juju deploy ./*.charm loki-off --resource loki-image=docker.io/ubuntu/loki:2-22.04 --resource node-exporter-image=docker.io/prom/node-exporter:v1.7.0 --config reporting-enabled=false --trust
juju ssh --container loki loki-off/0 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> reporting_enabled: false
```
3. Toggle the reporting config
```
juju config loki-off reporting-enabled=true
juju ssh --container loki loki-off/0 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> null
```
4. Scale the application up
``` 
juju add-unit loki-off -n 1
jssh --container loki loki-off/1 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> null
```
5. Toggle the config
``` 
juju config loki-off reporting-enabled=false
jssh --container loki loki-off/1 cat /etc/loki/loki-local-config.yaml | yq -r '.analytics'
-> reporting_enabled: false
``` 


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
