### PR TITLE
Workload tracing

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -76,9 +76,16 @@ requires:
       Certificate and key files for the loki server.
   catalogue:
     interface: catalogue
-  tracing:
-    interface: tracing
+  charm-tracing:
+    description: |
+      Enables sending charm traces to a distributed tracing backend such as Tempo.
     limit: 1
+    interface: tracing
+  workload-tracing:
+    description: |
+      Enables sending workload traces to a distributed tracing backend such as Tempo.
+    limit: 1
+    interface: tracing
 
 peers:
   replicas:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -13,7 +13,11 @@ from urllib.parse import urljoin
 
 import requests
 import yaml
+from juju.application import Application
+from juju.unit import Unit
+from minio import Minio
 from pytest_operator.plugin import OpsTest
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -468,3 +472,102 @@ async def delete_pod(model_name: str, app_name: str, unit_num: int) -> bool:
     except subprocess.CalledProcessError as e:
         logger.error(e.stdout.decode())
         raise e
+
+
+async def deploy_and_configure_minio(ops_test: OpsTest) -> None:
+    """Deploy and set up minio and s3-integrator needed for s3-like storage backend in the HA charms."""
+    config = {
+        "access-key": "accesskey",
+        "secret-key": "secretkey",
+    }
+    await ops_test.model.deploy("minio", channel="edge", trust=True, config=config)
+    await ops_test.model.wait_for_idle(apps=["minio"], status="active", timeout=2000)
+    minio_addr = await get_unit_address(ops_test, "minio", 0)
+
+    mc_client = Minio(
+        f"{minio_addr}:9000",
+        access_key="accesskey",
+        secret_key="secretkey",
+        secure=False,
+    )
+
+    # create tempo bucket
+    found = mc_client.bucket_exists("tempo")
+    if not found:
+        mc_client.make_bucket("tempo")
+
+    # configure s3-integrator
+    s3_integrator_app: Application = ops_test.model.applications["s3-integrator"]
+    s3_integrator_leader: Unit = s3_integrator_app.units[0]
+
+    await s3_integrator_app.set_config(
+        {
+            "endpoint": f"minio-0.minio-endpoints.{ops_test.model.name}.svc.cluster.local:9000",
+            "bucket": "tempo",
+        }
+    )
+
+    action = await s3_integrator_leader.run_action("sync-s3-credentials", **config)
+    action_result = await action.wait()
+    assert action_result.status == "completed"
+
+
+async def deploy_tempo_cluster(ops_test: OpsTest):
+    """Deploys tempo in its HA version together with minio and s3-integrator."""
+    tempo_app = "tempo"
+    worker_app = "tempo-worker"
+    tempo_worker_charm_url, worker_channel = "tempo-worker-k8s", "edge"
+    tempo_coordinator_charm_url, coordinator_channel = "tempo-coordinator-k8s", "edge"
+    await ops_test.model.deploy(
+        tempo_worker_charm_url, application_name=worker_app, channel=worker_channel, trust=True
+    )
+    await ops_test.model.deploy(
+        tempo_coordinator_charm_url,
+        application_name=tempo_app,
+        channel=coordinator_channel,
+        trust=True,
+    )
+    await ops_test.model.deploy("s3-integrator", channel="edge")
+
+    await ops_test.model.integrate(tempo_app + ":s3", "s3-integrator" + ":s3-credentials")
+    await ops_test.model.integrate(tempo_app + ":tempo-cluster", worker_app + ":tempo-cluster")
+
+    await deploy_and_configure_minio(ops_test)
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[tempo_app, worker_app, "s3-integrator"],
+            status="active",
+            timeout=2000,
+            idle_period=30,
+        )
+
+
+def get_traces(tempo_host: str, service_name="tracegen-otlp_http", tls=True):
+    """Get traces directly from Tempo REST API."""
+    url = f"{'https' if tls else 'http'}://{tempo_host}:3200/api/search?tags=service.name={service_name}"
+    req = requests.get(
+        url,
+        verify=False,
+    )
+    assert req.status_code == 200
+    traces = json.loads(req.text)["traces"]
+    return traces
+
+
+@retry(stop=stop_after_attempt(15), wait=wait_exponential(multiplier=1, min=4, max=10))
+async def get_traces_patiently(tempo_host, service_name="tracegen-otlp_http", tls=True):
+    """Get traces directly from Tempo REST API, but also try multiple times.
+
+    Useful for cases when Tempo might not return the traces immediately (its API is known for returning data in
+    random order).
+    """
+    traces = get_traces(tempo_host, service_name=service_name, tls=tls)
+    assert len(traces) > 0
+    return traces
+
+
+async def get_application_ip(ops_test: OpsTest, app_name: str) -> str:
+    """Get the application IP address."""
+    status = await ops_test.model.get_status()
+    app = status["applications"][app_name]
+    return app.public_address

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import deploy_tempo_cluster, get_application_ip, get_traces_patiently, is_loki_up
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+app_name = "loki"
+TEMPO_APP_NAME = "tempo"
+loki_resources = {
+    "loki-image": METADATA["resources"]["loki-image"]["upstream-source"],
+    "node-exporter-image": METADATA["resources"]["node-exporter-image"]["upstream-source"],
+}
+
+
+async def test_setup_env(ops_test):
+    await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
+
+
+@pytest.mark.abort_on_fail
+async def test_workload_tracing_is_present(ops_test, loki_charm):
+    logger.info("deploying tempo cluster")
+    await deploy_tempo_cluster(ops_test)
+
+    logger.info("deploying local charm")
+    await ops_test.model.deploy(
+        loki_charm, resources=loki_resources, application_name=app_name, trust=True
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[app_name], status="active", timeout=300, wait_for_exact_units=1
+    )
+
+    # we relate _only_ workload tracing not to confuse with charm traces
+    await ops_test.model.add_relation(
+        "{}:workload-tracing".format(app_name), "{}:tracing".format(TEMPO_APP_NAME)
+    )
+    # but we also need anything to come in to loki so that loki generates traces
+    await ops_test.model.add_relation(
+        "{}:logging".format(TEMPO_APP_NAME), "{}:logging".format(app_name)
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active")
+    assert await is_loki_up(ops_test, app_name, num_units=1)
+
+    # Verify workload traces from grafana are ingested into Tempo
+    assert await get_traces_patiently(
+        await get_application_ip(ops_test, TEMPO_APP_NAME),
+        service_name=f"{app_name}",
+        tls=False,
+    )

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -48,7 +48,7 @@ async def test_workload_tracing_is_present(ops_test, loki_charm):
     await ops_test.model.wait_for_idle(apps=[app_name], status="active")
     assert await is_loki_up(ops_test, app_name, num_units=1)
 
-    # Verify workload traces from grafana are ingested into Tempo
+    # Verify workload traces are ingested into Tempo
     assert await get_traces_patiently(
         await get_application_ip(ops_test, TEMPO_APP_NAME),
         service_name=f"{app_name}",

--- a/tox.ini
+++ b/tox.ini
@@ -94,5 +94,7 @@ deps =
     juju
     pytest
     pytest-operator
+    cosl
+    minio
 commands =
     pytest -v --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Loki was missing workload traces. 


## Solution
<!-- A summary of the solution addressing the above issue -->
Configure Loki to send workload traces using environment variables.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Implemented workload traces with an assumption of the split to charm and workload traces, as descibed here: https://discourse.charmhub.io/t/cos-endpoint-split-into-charm-tracing-and-workload-tracing/15978



## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See that the integration tests pass, or run the following bundle:
```
bundle: kubernetes
applications:
  loki:
    charm: local:loki-k8s-0
    base: ubuntu@20.04/stable
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  minio:
    charm: minio
    channel: latest/edge
    revision: 383
    base: ubuntu@20.04/stable
    resources:
      oci-image: 545
    scale: 1
    options:
      access-key: accesskey
      secret-key: secretkey
    constraints: arch=amd64
    storage:
      minio-data: kubernetes,1,10240M
    trust: true
  s3-integrator:
    charm: s3-integrator
    channel: latest/edge
    revision: 83
    scale: 1
    options:
      bucket: tempo
      endpoint: minio-0.minio-endpoints.test-workload-tracing-5vcc.svc.cluster.local:9000
    constraints: arch=amd64
  tempo:
    charm: tempo-coordinator-k8s
    channel: latest/edge
    revision: 37
    resources:
      nginx-image: 5
      nginx-prometheus-exporter-image: 3
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-worker:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 40
    resources:
      tempo-image: 4
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
relations:
- - tempo:s3
  - s3-integrator:s3-credentials
- - tempo:tempo-cluster
  - tempo-worker:tempo-cluster
- - loki:workload-tracing
  - tempo:tracing
- - tempo:logging
  - loki:logging
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
If you have COS components deployed together with Tempo and related using a tracing integration in your Juju model, please remove the tracing relation before the upgrade and re-relate the applications to tempo after the upgrade.