### PR TITLE
Implement `grafana_datasource_exchange`

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -162,7 +162,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 24
 
 logger = logging.getLogger(__name__)
 
@@ -432,13 +432,22 @@ class GrafanaSourceProvider(Object):
     def get_source_uids(self) -> Dict[str, Dict[str, str]]:
         """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from remote application names to unit names to datasource uids.
+        Returns a mapping from remote application UIDs to unit names to datasource uids.
         """
         uids = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            uids[rel.app.name] = json.loads(rel.data[rel.app]["datasource_uids"])
+            app_databag = rel.data[rel.app]
+            grafana_uid = app_databag.get("grafana_uid")
+            if not grafana_uid:
+                logger.warning(
+                    "remote end is using an old grafana_datasource interface: "
+                    "`grafana_uid` field not found."
+                )
+                continue
+
+            uids[grafana_uid] = json.loads(app_databag.get("datasource_uids", "{}"))
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:
@@ -568,6 +577,14 @@ class GrafanaSourceConsumer(Object):
 
         Assumes only leader unit will call this method
         """
+        unique_grafana_name = "juju_{}_{}_{}_{}".format(
+            self._charm.model.name,
+            self._charm.model.uuid,
+            self._charm.model.app.name,
+            self._charm.model.unit.name.split("/")[1],  # type: ignore
+        )
+
+        rel.data[self._charm.app]["grafana_uid"] = unique_grafana_name
         rel.data[self._charm.app]["datasource_uids"] = json.dumps(uids)
 
     def _get_source_config(self, rel: Relation):

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -154,8 +154,6 @@ from ops.framework import (
 )
 from ops.model import Relation
 
-from charms.observability_libs.v0.juju_topology import JujuTopology
-
 # The unique Charmhub library identifier, never change it
 LIBID = "974705adb86f40228298156e34b460dc"
 
@@ -164,7 +162,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 22
 
 logger = logging.getLogger(__name__)
 
@@ -434,22 +432,13 @@ class GrafanaSourceProvider(Object):
     def get_source_uids(self) -> Dict[str, Dict[str, str]]:
         """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from remote application UIDs to unit names to datasource uids.
+        Returns a mapping from remote application names to unit names to datasource uids.
         """
         uids = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            app_databag = rel.data[rel.app]
-            grafana_uid = app_databag.get("grafana_uid")
-            if not grafana_uid:
-                logger.warning(
-                    "remote end is using an old grafana_datasource interface: "
-                    "`grafana_uid` field not found."
-                )
-                continue
-
-            uids[grafana_uid] = json.loads(app_databag.get("datasource_uids", "{}"))
+            uids[rel.app.name] = json.loads(rel.data[rel.app]["datasource_uids"])
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:
@@ -579,15 +568,6 @@ class GrafanaSourceConsumer(Object):
 
         Assumes only leader unit will call this method
         """
-        juju_topology = JujuTopology.from_charm(self._charm)
-        unique_grafana_name = "juju_{}_{}_{}_{}".format(
-            juju_topology.model,
-            juju_topology.model_uuid,
-            juju_topology.application,
-            juju_topology.unit.split("/")[1],
-        )
-
-        rel.data[self._charm.app]["grafana_uid"] = unique_grafana_name
         rel.data[self._charm.app]["datasource_uids"] = json.dumps(uids)
 
     def _get_source_config(self, rel: Relation):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -62,6 +62,10 @@ provides:
     interface: prometheus_scrape
   grafana-dashboard:
     interface: grafana_dashboard
+  send-datasource:
+    interface: grafana_datasource_exchange
+    description: |
+      Integration to share with other COS components this charm's grafana datasources, and receive theirs.
 
 requires:
   alertmanager:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cosl>=0.0.46
+cosl>=0.0.47
 # pinned to 2.16 as 2.17 breaks our unittests
 ops
 kubernetes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cosl>=0.0.12
+cosl>=0.0.46
 # pinned to 2.16 as 2.17 breaks our unittests
 ops
 kubernetes

--- a/src/charm.py
+++ b/src/charm.py
@@ -898,6 +898,9 @@ class LokiOperatorCharm(CharmBase):
 
     def _update_datasource_exchange(self) -> None:
         """Update the grafana-datasource-exchange relations."""
+        if not self.unit.is_leader():
+            return
+
         grafana_uids_to_units_to_uids = self.grafana_source_provider.get_source_uids()
         raw_datasources: List[DatasourceDict] = []
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -539,6 +539,8 @@ async def deploy_tempo_cluster(ops_test: OpsTest):
             status="active",
             timeout=2000,
             idle_period=30,
+            # FIXME: intermittent issue where tempo momentarily goes into error state
+            raise_on_error=False,
         )
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -539,7 +539,7 @@ async def deploy_tempo_cluster(ops_test: OpsTest):
             status="active",
             timeout=2000,
             idle_period=30,
-            # FIXME: intermittent issue where tempo momentarily goes into error state
+            # TODO: remove when https://github.com/canonical/tempo-coordinator-k8s-operator/issues/90 is fixed
             raise_on_error=False,
         )
 

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -52,9 +52,7 @@ grafana_source_relation = Relation(
 grafana_datasource_exchange_relation = Relation(
     "send-datasource",
     remote_app_data={
-        "datasources": json.dumps(
-            {"loki/0": {"type": "loki", "uid": "01234", "grafana_uid": "5678"}}
-        )
+        "datasources": json.dumps([{"type": "loki", "uid": "01234", "grafana_uid": "5678"}])
     },
 )
 

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import ops
+import pytest
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from interface_tester import InterfaceTester
+from ops import ActiveStatus
+from scenario.state import Container, Exec, Relation, State
+
+from charm import LokiOperatorCharm
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_all():
+    with ExitStack() as stack:
+        stack.enter_context(patch("lightkube.core.client.GenericSyncClient"))
+        stack.enter_context(
+            patch.multiple(
+                "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+                is_ready=MagicMock(return_value=True),
+                get_status=lambda _: ActiveStatus(""),
+            )
+        )
+        stack.enter_context(charm_tracing_disabled())
+
+        yield
+
+
+loki_container = Container(
+    name="loki",
+    can_connect=True,
+    execs={Exec(["update-ca-certificates", "--fresh"], return_code=0)},
+    layers={"loki": ops.pebble.Layer({"services": {"loki": {}}})},
+    service_statuses={"loki": ops.pebble.ServiceStatus.ACTIVE},
+)
+
+grafana_source_relation = Relation(
+    "grafana-source",
+    remote_app_data={
+        "datasource_uids": json.dumps({"loki/0": "01234"}),
+        "grafana_uid": "5678",
+    },
+)
+
+grafana_datasource_exchange_relation = Relation(
+    "send-datasource",
+    remote_app_data={
+        "datasources": json.dumps(
+            {"loki/0": {"type": "loki", "uid": "01234", "grafana_uid": "5678"}}
+        )
+    },
+)
+
+
+@pytest.fixture
+def grafana_datasource_tester(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        charm_type=LokiOperatorCharm,
+        state_template=State(
+            leader=True, containers=[loki_container], relations=[grafana_source_relation]
+        ),
+    )
+    yield interface_tester
+
+
+@pytest.fixture
+def grafana_datasource_exchange_tester(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        charm_type=LokiOperatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[loki_container],
+            relations=[grafana_source_relation, grafana_datasource_exchange_relation],
+        ),
+    )
+    yield interface_tester

--- a/tests/interface/test_grafana_datasource_exchange.py
+++ b/tests/interface/test_grafana_datasource_exchange.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from interface_tester import InterfaceTester
+
+
+def test_grafana_datasource_exchange_v0_interface(
+    grafana_datasource_exchange_tester: InterfaceTester,
+):
+    grafana_datasource_exchange_tester.configure(
+        interface_name="grafana_datasource_exchange",
+        interface_version=0,
+    )
+    grafana_datasource_exchange_tester.run()

--- a/tests/interface/test_grafana_source.py
+++ b/tests/interface/test_grafana_source.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from interface_tester import InterfaceTester
+
+
+def test_grafana_datasource_v0_interface(grafana_datasource_tester: InterfaceTester):
+    grafana_datasource_tester.configure(
+        interface_name="grafana_datasource",
+        interface_version=0,
+    )
+    grafana_datasource_tester.run()

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -24,8 +24,7 @@ def loki_charm(tmp_path):
         with patch("socket.getfqdn", new=lambda *args: "fqdn"):
             with patch("lightkube.core.client.GenericSyncClient"):
                 with charm_tracing_disabled():
-                    with patch("subprocess.run"):
-                        yield LokiOperatorCharm
+                    yield LokiOperatorCharm
 
 
 @pytest.fixture

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,7 +1,10 @@
 from unittest.mock import PropertyMock, patch
 
+import ops
 import pytest
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from ops.testing import Context
+from scenario import Container, Exec
 
 from charm import LokiOperatorCharm
 
@@ -11,7 +14,7 @@ def tautology(*_, **__) -> bool:
 
 
 @pytest.fixture
-def loki_charm():
+def loki_charm(tmp_path):
     with patch.multiple(
         "charm.KubernetesComputeResourcesPatch",
         _namespace=PropertyMock("test-namespace"),
@@ -20,9 +23,22 @@ def loki_charm():
     ):
         with patch("socket.getfqdn", new=lambda *args: "fqdn"):
             with patch("lightkube.core.client.GenericSyncClient"):
-                yield LokiOperatorCharm
+                with charm_tracing_disabled():
+                    with patch("subprocess.run"):
+                        yield LokiOperatorCharm
 
 
 @pytest.fixture
 def context(loki_charm):
     return Context(loki_charm)
+
+
+@pytest.fixture(scope="function")
+def loki_container():
+    return Container(
+        "loki",
+        can_connect=True,
+        execs={Exec(["update-ca-certificates", "--fresh"], return_code=0)},
+        layers={"loki": ops.pebble.Layer({"services": {"loki": {}}})},
+        service_statuses={"loki": ops.pebble.ServiceStatus.INACTIVE},
+    )

--- a/tests/scenario/test_datasource_exchange.py
+++ b/tests/scenario/test_datasource_exchange.py
@@ -1,0 +1,78 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+
+import pytest
+from cosl.interfaces.datasource_exchange import (
+    DatasourceExchange,
+    DSExchangeAppData,
+    GrafanaDatasource,
+)
+from scenario import Relation, State
+
+from charm import LokiOperatorCharm
+
+ds_tempo = [
+    {"type": "tempo", "uid": "3", "grafana_uid": "4"},
+]
+
+ds_mimir = [
+    {"type": "prometheus", "uid": "8", "grafana_uid": "9"},
+]
+
+mimir_dsx = Relation(
+    "send-datasource",
+    remote_app_data=DSExchangeAppData(datasources=json.dumps(ds_mimir)).dump(),
+)
+tempo_dsx = Relation(
+    "send-datasource",
+    remote_app_data=DSExchangeAppData(datasources=json.dumps(ds_tempo)).dump(),
+)
+
+ds = Relation(
+    "grafana-source",
+    remote_app_data={
+        "grafana_uid": "9",
+        "datasource_uids": json.dumps({"loki/0": "1234"}),
+    },
+)
+
+
+@pytest.mark.parametrize("event_type", ("changed", "created", "joined"))
+@pytest.mark.parametrize("relation_to_observe", (ds, mimir_dsx, tempo_dsx))
+def test_datasource_send(context, loki_container, relation_to_observe, event_type):
+
+    state_in = State(
+        relations=[
+            ds,
+            mimir_dsx,
+            tempo_dsx,
+        ],
+        containers=[loki_container],
+        leader=True,
+    )
+
+    # WHEN we receive a datasource-related event
+    with context(
+        getattr(context.on, f"relation_{event_type}")(relation_to_observe), state_in
+    ) as mgr:
+        charm: LokiOperatorCharm = mgr.charm
+        # THEN we can find all received datasource uids
+        dsx: DatasourceExchange = charm.datasource_exchange
+        received = dsx.received_datasources
+        assert received == (
+            GrafanaDatasource(type="tempo", uid="3", grafana_uid="4"),
+            GrafanaDatasource(type="prometheus", uid="8", grafana_uid="9"),
+        )
+        state_out = mgr.run()
+
+    # AND THEN we publish our own datasource information to mimir and tempo
+    published_dsx_mimir = state_out.get_relation(mimir_dsx.id).local_app_data
+    published_dsx_tempo = state_out.get_relation(tempo_dsx.id).local_app_data
+    assert published_dsx_tempo == published_dsx_mimir
+    assert json.loads(published_dsx_tempo["datasources"])[0] == {
+        "type": "loki",
+        "uid": "1234",
+        "grafana_uid": "9",
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -98,3 +98,12 @@ deps =
     minio
 commands =
     pytest -v --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
+
+[testenv:interface]
+description = Run interface tests
+deps =
+    pytest
+    -r{toxinidir}/requirements.txt
+    pytest-interface-tester
+commands =
+    pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/interface


### PR DESCRIPTION
## Issue
Add a `send-datasource` endpoint to exchange datasource UIDs with other COS components.

## Context
TODO:
- [x] merge `grafana_source` lib https://github.com/canonical/grafana-k8s-operator/pull/364

## Testing Instructions
1. Deploy Tempo HA
2. Deploy `grafana-k8s`
3. Deploy `loki-k8s` from this branch
4. Integrate `tempo` and `grafana` over `grafana_datasource`
5. Integrate `loki` and `grafana` over `grafana_datasource`
6. Integrate `loki` and `tempo` over `grafana_datasource_exchange`
7. `jhack show-relation loki tempo` and observe the datasource UID of `loki` shared to `tempo` 
