### PR TITLE
fix: update cos-tool permissions to adhere to cis hardening rules

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,4 +26,4 @@ parts:
       - curl
     override-pull: |
       curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
-      chmod +x cos-tool-*
+      chmod 775 cos-tool-*

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -2498,10 +2498,7 @@ class CosTool:
         res = "cos-tool-{}".format(arch)
         try:
             path = Path(res).resolve()
-            path.chmod(0o775)
             return path
-        except NotImplementedError:
-            logger.debug("System lacks support for chmod")
         except FileNotFoundError:
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -485,7 +485,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 30
+LIBPATCH = 31
 
 PYDEPS = ["cosl"]
 
@@ -1975,7 +1975,9 @@ class LogProxyConsumer(ConsumerBase):
             },
         }
         self._container.add_layer(
-            self._container_name, pebble_layer, combine=True  # pyright: ignore
+            self._container_name,
+            pebble_layer,
+            combine=True,  # pyright: ignore
         )
 
     def _create_directories(self) -> None:
@@ -2496,7 +2498,7 @@ class CosTool:
         res = "cos-tool-{}".format(arch)
         try:
             path = Path(res).resolve()
-            path.chmod(0o777)
+            path.chmod(0o775)
             return path
         except NotImplementedError:
             logger.debug("System lacks support for chmod")

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -2497,9 +2497,9 @@ class CosTool:
         arch = "amd64" if arch == "x86_64" else arch
         res = "cos-tool-{}".format(arch)
         try:
-            path = Path(res).resolve()
+            path = Path(res).resolve(strict=True)
             return path
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -485,7 +485,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 31
+LIBPATCH = 32
 
 PYDEPS = ["cosl"]
 
@@ -1976,7 +1976,7 @@ class LogProxyConsumer(ConsumerBase):
         }
         self._container.add_layer(
             self._container_name,
-            pebble_layer,
+            pebble_layer,  # pyright: ignore
             combine=True,  # pyright: ignore
         )
 


### PR DESCRIPTION
## Issue
Needed for the following PR: https://github.com/canonical/grafana-agent-operator/pull/231
More info on the CIS hardening rule can be found here[^1].


## Solution
Use `path.chmod(0o775)` in order to comply wit the CIS Hardening rules.

[^1]: https://github.com/canonical/grafana-agent-operator/issues/208