### PR TITLE
feat: add support for disabling alert rules forwarding

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -2593,8 +2593,6 @@ class LogForwarder(ConsumerBase):
         self.framework.observe(on.relation_departed, self._update_logging)
         self.framework.observe(on.relation_broken, self._update_logging)
 
-        self.framework.observe(on.config_changed, self._update_logging)
-
         if refresh_event:
             if not isinstance(refresh_event, list):
                 refresh_event = [refresh_event]

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1543,6 +1543,7 @@ class ConsumerBase(Object):
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         recursive: bool = False,
         skip_alert_topology_labeling: bool = False,
+        *,
         forward_alert_rules: bool = True,
     ):
         super().__init__(charm, relation_name)

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -2563,6 +2563,7 @@ class LogForwarder(ConsumerBase):
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         recursive: bool = True,
         skip_alert_topology_labeling: bool = False,
+        *,
         forward_alert_rules: bool = True,
     ):
         _PebbleLogClient.check_juju_version()

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -546,7 +546,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 PYDEPS = ["cosl"]
 
@@ -1695,7 +1695,7 @@ class LokiPushApiConsumer(ConsumerBase):
             if not isinstance(refresh_event, list):
                 refresh_event = [refresh_event]
             for ev in refresh_event:
-                self.framework.observe(ev, self._push_alerts_to_all_relation_databags)
+                self.framework.observe(ev, self._on_lifecycle_event)
 
     def _on_lifecycle_event(self, _: HookEvent):
         """Update require relation data on charm upgrades and other lifecycle events.

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -546,7 +546,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["cosl"]
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1621,6 +1621,7 @@ class LokiPushApiConsumer(ConsumerBase):
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         recursive: bool = True,
         skip_alert_topology_labeling: bool = False,
+        *,
         forward_alert_rules: bool = True,
     ):
         """Construct a Loki charm client.


### PR DESCRIPTION
## Issue
Partially addresses https://github.com/canonical/grafana-agent-operator/issues/154


## Solution
Allow charm authors to pass `forward_alert_rules=False` to both `LokiPushApiConsumer` and `LogForwarder` (pebble log forwarding).

When the flag is `True`, the alert rules information is simply not put in relation data.

## Testing Instructions
Pack and deploy both this charm and grafana-agent from https://github.com/canonical/grafana-agent-operator/pull/252 , and test the new config option.