### PR TITLE
feat: add grafana_base_url to Grafana source

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -432,21 +432,14 @@ class GrafanaSourceProvider(Object):
     def get_grafana_base_urls(self) -> Dict[str, str]:
         """Get the grafana base URL (potentially ingressed) assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from remote application UIDs to URL.
+        Returns a mapping from relation ID to URL.
         """
         urls = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
             app_databag = rel.data[rel.app]
-            grafana_uid = app_databag.get("grafana_uid")
-            if not grafana_uid:
-                logger.warning(
-                    "remote end is using an old grafana_datasource interface: "
-                    "`grafana_uid` field not found."
-                )
-                continue
-            urls[grafana_uid] = app_databag.get("grafana_base_url")
+            urls[rel.id] = app_databag.get("grafana_base_url")
         return urls
 
     def get_source_uids(self) -> Dict[str, Dict[str, str]]:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -430,10 +430,9 @@ class GrafanaSourceProvider(Object):
             self._set_sources(rel)
 
     def get_grafana_base_urls(self) -> Dict[str, str]:
-        # TODO update docstring
-        """Get the grafana external URL assigned by the remote end(s) to this datasource.
+        """Get the grafana base URL (potentially ingressed) assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from remote application UIDs to unit names to datasource uids.
+        Returns a mapping from remote application UIDs to URL.
         """
         urls = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -131,6 +131,7 @@ import json
 import logging
 import re
 import socket
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 from ops.charm import (
@@ -169,6 +170,22 @@ logger = logging.getLogger(__name__)
 DEFAULT_RELATION_NAME = "grafana-source"
 DEFAULT_PEER_NAME = "grafana"
 RELATION_INTERFACE_NAME = "grafana_datasource"
+
+
+@dataclass
+class GrafanaSourceData:
+    """This class represents the data Grafana provides others about itself."""
+
+    datasource_uids: Dict[str, str]
+    external_url: str
+
+    def get_unit_uid(self, unit: str):
+        """Return the UID for a given unit."""
+        if unit in self.datasource_uids:
+            datasource_uid = self.datasource_uids[unit]
+        else:
+            datasource_uid = ""
+        return datasource_uid
 
 
 def _type_convert_stored(obj) -> Union[dict, list]:
@@ -429,25 +446,12 @@ class GrafanaSourceProvider(Object):
                 continue
             self._set_sources(rel)
 
-    def get_grafana_base_urls(self) -> Dict[str, str]:
-        """Get the grafana base URL (potentially ingressed) assigned by the remote end(s) to this datasource.
+    def get_source_data(self) -> Dict[str, GrafanaSourceData]:
+        """Get the Grafana data assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from relation ID to URL.
+        Returns a mapping from remote application UIDs to GrafanaSourceData.
         """
-        urls = {}
-        for rel in self._charm.model.relations.get(self._relation_name, []):
-            if not rel:
-                continue
-            app_databag = rel.data[rel.app]
-            urls[rel.id] = app_databag.get("grafana_base_url")
-        return urls
-
-    def get_source_uids(self) -> Dict[str, Dict[str, str]]:
-        """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
-
-        Returns a mapping from remote application UIDs to unit names to datasource uids.
-        """
-        uids = {}
+        data = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
@@ -459,9 +463,22 @@ class GrafanaSourceProvider(Object):
                     "`grafana_uid` field not found."
                 )
                 continue
+            grafana_data = GrafanaSourceData(
+                datasource_uids=json.loads(app_databag.get("datasource_uids", "{}")),
+                external_url=app_databag.get("grafana_base_url", "")
+            )
+            data[grafana_uid] = grafana_data
+        return data
 
-            uids[grafana_uid] = json.loads(app_databag.get("datasource_uids", "{}"))
-        return uids
+    def get_source_uids(self) -> Dict[str, Dict[str, str]]:
+        """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
+
+        Returns a mapping from remote application UIDs to unit names to datasource uids.
+
+        Use the `get_source_data` public method instead.
+        """
+        data = self.get_source_data()
+        return {grafana_uid: data[grafana_uid].datasource_uids for grafana_uid in data}
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:
         """Get a `Relation` object from the event to pass on."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -615,7 +615,7 @@ class LokiOperatorCharm(CharmBase):
             2. Loki is the datasource so it doesn't matter which Grafana UI shows the query
         """
         nested_data = self.grafana_source_provider.get_source_data()
-        return nested_data[sorted(nested_data)[0]] if nested_data else GrafanaSourceData({}, "")
+        return nested_data[sorted(nested_data)[0]] if nested_data else GrafanaSourceData({}, None)
 
     def _update_config(self, config: dict) -> bool:
         if self._running_config() != config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -565,6 +565,7 @@ class LokiOperatorCharm(CharmBase):
             http_tls=self._tls_ready,
             tsdb_versions_migration_dates=self._tsdb_versions_migration_dates,
             reporting_enabled=bool(self.config["reporting-enabled"]),
+            grafana_external_url=self.grafana_source_provider.get_grafana_base_url()
         ).build()
 
         # Add a layer so we can check if the service is running

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -57,6 +57,7 @@ class ConfigBuilder:
         tsdb_versions_migration_dates: Optional[List[Dict[str, str]]] = None,
         reporting_enabled: bool,
         grafana_external_url: str,
+        datasource_uid: str,
     ):
         """Init method."""
         self.instance_addr = instance_addr
@@ -69,6 +70,7 @@ class ConfigBuilder:
         self.tsdb_versions_migration_dates = tsdb_versions_migration_dates or []
         self.reporting_enabled = reporting_enabled
         self.grafana_external_url = grafana_external_url
+        self.datasource_uid = datasource_uid
 
     def build(self) -> dict:
         """Build Loki config dictionary."""
@@ -122,12 +124,14 @@ class ConfigBuilder:
     @property
     def _ruler(self) -> dict:
         # Reference: https://grafana.com/docs/loki/latest/configure/#ruler
-        return {
+        ruler_config = {
             "alertmanager_url": self.alertmanager_url,
-            "external_url": self.grafana_external_url,
-            # "datasource_uid": "juju_am-test_3688ddf4-84ec-4f55-81da-5afc4166105d_loki_0",
             "enable_alertmanager_v2": True,
+            "datasource_uid": self.datasource_uid,
         }
+        if self.grafana_external_url:  # external_url has no default so we conditionally add it
+            ruler_config.update({"external_url": self.grafana_external_url})
+        return ruler_config
 
     @property
     def _schema_config(self) -> dict:

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -56,6 +56,7 @@ class ConfigBuilder:
         http_tls: bool = False,
         tsdb_versions_migration_dates: Optional[List[Dict[str, str]]] = None,
         reporting_enabled: bool,
+        grafana_external_url: str,
     ):
         """Init method."""
         self.instance_addr = instance_addr
@@ -120,9 +121,11 @@ class ConfigBuilder:
     @property
     def _ruler(self) -> dict:
         # Reference: https://grafana.com/docs/loki/latest/configure/#ruler
+        first_key = next(iter(self.grafana_external_url))
         return {
             "alertmanager_url": self.alertmanager_url,
-            "external_url": self.external_url,
+            "external_url": self.grafana_external_url[first_key],
+            # "datasource_uid": "juju_am-test_3688ddf4-84ec-4f55-81da-5afc4166105d_loki_0",
             "enable_alertmanager_v2": True,
         }
 

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -56,7 +56,7 @@ class ConfigBuilder:
         http_tls: bool = False,
         tsdb_versions_migration_dates: Optional[List[Dict[str, str]]] = None,
         reporting_enabled: bool,
-        grafana_external_url: str,
+        grafana_external_url: Optional[str],
         datasource_uid: str,
     ):
         """Init method."""

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -68,6 +68,7 @@ class ConfigBuilder:
         self.retention_period = retention_period
         self.tsdb_versions_migration_dates = tsdb_versions_migration_dates or []
         self.reporting_enabled = reporting_enabled
+        self.grafana_external_url = grafana_external_url
 
     def build(self) -> dict:
         """Build Loki config dictionary."""
@@ -121,10 +122,9 @@ class ConfigBuilder:
     @property
     def _ruler(self) -> dict:
         # Reference: https://grafana.com/docs/loki/latest/configure/#ruler
-        first_key = next(iter(self.grafana_external_url))
         return {
             "alertmanager_url": self.alertmanager_url,
-            "external_url": self.grafana_external_url[first_key],
+            "external_url": self.grafana_external_url,
             # "datasource_uid": "juju_am-test_3688ddf4-84ec-4f55-81da-5afc4166105d_loki_0",
             "enable_alertmanager_v2": True,
         }

--- a/tests/scenario/test_grafana_source.py
+++ b/tests/scenario/test_grafana_source.py
@@ -51,4 +51,4 @@ def test_sorted_source_data_no_relations(context, loki_container):
     with context(context.on.update_status(), state_in) as mgr:
         charm: LokiOperatorCharm = mgr.charm
         # THEN we receive an empty GrafanaSourceData instance
-        assert charm._sorted_source_data() == GrafanaSourceData({}, "")
+        assert charm._sorted_source_data() == GrafanaSourceData({}, None)

--- a/tests/scenario/test_grafana_source.py
+++ b/tests/scenario/test_grafana_source.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+
+from charms.grafana_k8s.v0.grafana_source import GrafanaSourceData
+from scenario import Relation, State
+
+from charm import LokiOperatorCharm
+
+
+def test_sorted_source_data(context, loki_container):
+    # GIVEN multiple "grafana-source" relations
+    rel_1 = Relation(
+        "grafana-source",
+        remote_app_name="grafana_one",
+        remote_app_data={
+            "grafana_uid": "1",
+            "datasource_uids": json.dumps({"loki/0": "first"}),
+            "grafana_base_url": "http://one",
+        },
+    )
+    rel_2 = Relation(
+        "grafana-source",
+        remote_app_name="grafana_two",
+        remote_app_data={
+            "grafana_uid": "2",
+            "datasource_uids": json.dumps({"loki/0": "second"}),
+            "grafana_base_url": "http://two",
+        },
+    )
+
+    state_in = State(
+        relations=[rel_1, rel_2],
+        containers=[loki_container],
+    )
+    # WHEN we receive any event
+    with context(context.on.update_status(), state_in) as mgr:
+        charm: LokiOperatorCharm = mgr.charm
+        # THEN we receive a single GrafanaSourceData instance, sorted by `grafana_uid`
+        assert charm._sorted_source_data() == GrafanaSourceData({"loki/0": "first"}, "http://one")
+
+
+def test_sorted_source_data_no_relations(context, loki_container):
+    # GIVEN no "grafana-source" relations
+    state_in = State(
+        relations=[],
+        containers=[loki_container],
+    )
+    # WHEN we receive any event
+    with context(context.on.update_status(), state_in) as mgr:
+        charm: LokiOperatorCharm = mgr.charm
+        # THEN we receive an empty GrafanaSourceData instance
+        assert charm._sorted_source_data() == GrafanaSourceData({}, "")


### PR DESCRIPTION
## Issue
Loki needs to know the Grafana base URL for its `ruler` config which may have an ingress. This is needed to correctly render the Source button URL to Grafana when Loki alert rules are firing:
![image](https://github.com/user-attachments/assets/6dad47c6-3761-4b79-b3c5-b2300b249805)
 
## Solution
Is this relation the best way to give Loki the ingress URL from Grafana? It makes sense since this scenario requires the `grafana-source` relation, otherwise Loki logs won't make it to Grafana and this scenario won't be possible.
- [x] Add tests for Loki consuming the grafana URL

## Context
- https://github.com/canonical/alertmanager-k8s-operator/issues/293
- https://github.com/canonical/grafana-k8s-operator/pull/398
- https://grafana.com/docs/loki/latest/configure/#ruler

## Testing Instructions
1. Create an always firing Loki alert rule in the [Zinc charm](https://github.com/jnsgruk/zinc-k8s-operator):
```yaml
alert: HostHighLogErrorRate
expr: count_over_time({juju_application="zinc"} [1h]) > -1
for: 0m
labels:
  severity: warning
annotations:
  summary: High error rate in logs (instance {{ $labels.instance }})
  description: "High error rate in logs\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
```
2. Pack the zinc charm
3. Deploy Zinc
4. Deploy cos-lite
```
curl -L https://raw.githubusercontent.com/canonical/cos-lite-bundle/main/overlays/offers-overlay.yaml -O
juju deploy cos-lite --trust --overlay ./offers-overlay.yaml
juju deploy 
```
5. Pack the Loki and Grafana charms with the changes in this PR and the tandem PR
6. `juju refresh` both charms with the packed charms
7. Relate Zinc to Loki for logging and generate some logs in the Zinc UI (log in or run a query)
8. Check the Alertmanager UI for the Source button link to Grafana ingress URL instead of Loki's ingress URL

- [x] Check that the config is empty until we receive a valid URL (how did this not error before?)
- [x] Check with multiple grafana's related
- [x] Check with multiple loki units to 1 Grafana
