### PR TITLE
feat: make reloading alerts public

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1608,20 +1608,6 @@ class ConsumerBase(Object):
 
         return endpoints
 
-    # @property
-    # def loki_otlp_endpoints(self) -> List[dict]:
-    #     """Fetch Loki OTLP API endpoints sent from LokiPushApiProvider through relation data.
-
-    #     Returns:
-    #         A list of dictionaries with Loki OTLP API endpoints (the otel-collector automatically completes the endpoint), for instance:
-    #         [
-    #             {"url": "http://loki1:3100/otlp"},
-    #             {"url": "http://loki2:3100/otlp"},
-    #         ]
-    #     """
-    #     from urllib.parse import urljoin
-    #     return [{"url": urljoin(e["url"], "/otlp")} for e in self.loki_endpoints]
-
 
 class LokiPushApiConsumer(ConsumerBase):
     """Loki Consumer class."""
@@ -1770,7 +1756,7 @@ class LokiPushApiConsumer(ConsumerBase):
 
         self.on.loki_push_api_endpoint_joined.emit()
 
-    def reload_alerts(self) -> None:  # TODO charmcraft fetch-lib in loki before PR
+    def reload_alerts(self) -> None:
         """Reloads alert rules and updates all relations."""
         self._reinitialize_alert_rules()
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -546,7 +546,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 PYDEPS = ["cosl"]
 
@@ -1608,6 +1608,20 @@ class ConsumerBase(Object):
 
         return endpoints
 
+    # @property
+    # def loki_otlp_endpoints(self) -> List[dict]:
+    #     """Fetch Loki OTLP API endpoints sent from LokiPushApiProvider through relation data.
+
+    #     Returns:
+    #         A list of dictionaries with Loki OTLP API endpoints (the otel-collector automatically completes the endpoint), for instance:
+    #         [
+    #             {"url": "http://loki1:3100/otlp"},
+    #             {"url": "http://loki2:3100/otlp"},
+    #         ]
+    #     """
+    #     from urllib.parse import urljoin
+    #     return [{"url": urljoin(e["url"], "/otlp")} for e in self.loki_endpoints]
+
 
 class LokiPushApiConsumer(ConsumerBase):
     """Loki Consumer class."""
@@ -1756,8 +1770,11 @@ class LokiPushApiConsumer(ConsumerBase):
 
         self.on.loki_push_api_endpoint_joined.emit()
 
-    def _reinitialize_alert_rules(self):
+    def reload_alerts(self) -> None:  # TODO charmcraft fetch-lib in loki before PR
         """Reloads alert rules and updates all relations."""
+        self._reinitialize_alert_rules()
+
+    def _reinitialize_alert_rules(self):
         for relation in self._charm.model.relations[self._relation_name]:
             self._handle_alert_rules(relation)
 


### PR DESCRIPTION
## Issue
Make the reloading alerts method public which is relevant in:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/7

This is done in [prometheus_remote_write with a reload_alerts method](https://github.com/canonical/prometheus-k8s-operator/blob/e09913477484f9ca006171ed949a9702bec3251e/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py#L509) so this PR mirrors this functionality.