### PR TITLE
Fix: use scheme in `_url` method

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1354,7 +1354,7 @@ class LokiPushApiProvider(Object):
 
         Return url to loki, including port number, but without the endpoint subpath.
         """
-        return "http://{}:{}".format(socket.getfqdn(), self.port)
+        return f"{self.scheme}://{socket.getfqdn()}:{self.port}"
 
     def _endpoint(self, url) -> dict:
         """Get Loki push API endpoint for a given url.


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
In the show-unit databag we see [the scheme is hardcoded](https://github.com/canonical/loki-k8s-operator/blob/f908515bbdbbb1b5bf39ca553eb32f2286c6785d/lib/charms/loki_k8s/v1/loki_push_api.py#L1357) to `http`.

`juju show-unit flog/0 | yq -r '."flog/0"."relation-info"'`
```
- relation-id: X
  related-units:
    otelcol/0:
      data:
        endpoint: '{"url": "http://otelcol-0.otelcol-endpoints.jubilant-26c3279b.svc.cluster.local:3500/loki/api/v1/push"}'
```
Regardless, if the related app endpoint is using TLS.


## Solution
<!-- A summary of the solution addressing the above issue -->
Use `self.scheme` in the `_url` method. Add a test to check this is working.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
First noticed [in this PR](https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/26)


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
