### PR TITLE
Remove xfails

### DIFF
--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -42,13 +42,12 @@ async def test_setup_env(ops_test: OpsTest):
     await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
 
 
-# @pytest.mark.abort_on_fail
-@pytest.mark.xfail
+@pytest.mark.abort_on_fail
 async def test_upgrade_edge_with_local_in_isolation(ops_test: OpsTest, loki_charm):
     """Deploy from charmhub and then upgrade with the charm-under-test."""
     logger.debug("deploy charm from charmhub")
     assert ops_test.model
-    sh.juju.deploy(app_name, app_name, model=ops_test.model.name, channel="edge", trust=True)
+    sh.juju.deploy(app_name, app_name, model=ops_test.model.name, channel="1/edge", trust=True)
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
     logger.debug("upgrade deployed charm with local charm %s", loki_charm)
@@ -57,8 +56,7 @@ async def test_upgrade_edge_with_local_in_isolation(ops_test: OpsTest, loki_char
     assert await is_loki_up(ops_test, app_name)
 
 
-# @pytest.mark.abort_on_fail
-@pytest.mark.xfail
+@pytest.mark.abort_on_fail
 async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, loki_charm):
     assert ops_test.model
     # Deploy related apps
@@ -85,8 +83,7 @@ async def test_upgrade_local_with_local_with_relations(ops_test: OpsTest, loki_c
     assert await is_loki_up(ops_test, app_name)
 
 
-# @pytest.mark.abort_on_fail
-@pytest.mark.xfail
+@pytest.mark.abort_on_fail
 async def test_upgrade_with_multiple_units(ops_test: OpsTest, loki_charm):
     assert ops_test.model
     app_names = [app_name, "am", "grafana"]


### PR DESCRIPTION
## Issue
Upgrade tests are marked as xfail.


## Solution
- Now that we only have 20.04 under platforms, upgrade test should work.
- In upgrade test, deploy from "1/edge".


## Context
When we add track branches to the repo, tests should pull from the matching track on charmhub.

