### PR TITLE
feat: Grafana-source unit-data flag

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -197,6 +197,7 @@ class LokiOperatorCharm(CharmBase):
             ],
             source_type="loki",
             source_url=self._external_url,
+            is_ingressed=self.ingress_per_unit.is_ready(),
         )
 
         self.metrics_provider = MetricsEndpointProvider(


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Only provide one Grafana data source (from the leader) when ingressed, otherwise each unit provides one.

## Solution
<!-- A summary of the solution addressing the above issue -->
Tandem PR:
- https://github.com/canonical/grafana-k8s-operator/pull/427

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- https://github.com/canonical/grafana-k8s-operator/pull/427#issuecomment-3090584719

Failing tests are mostly fixed in this PR:
- https://github.com/canonical/loki-k8s-operator/pull/524
