### PR TITLE
chore: add api endpoints and docs to catalogue item

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -374,6 +374,15 @@ class LokiOperatorCharm(CharmBase):
 
     @property
     def _catalogue_item(self) -> CatalogueItem:
+        api_endpoints = {
+            "Instant query": "/loki/api/v1/query",
+            "Query range": "/loki/api/v1/query_range",
+            "Labels": "/loki/api/v1/labels",
+            "Label values": "/loki/api/v1/label/<name>/values",
+            "Prometheus alerts": "/prometheus/api/v1/alerts",
+            "Prometheus rules": "/prometheus/api/v1/alerts",
+            "Format query": "/loki/api/v1/format_query"
+        }
         return CatalogueItem(
             name="Loki",
             icon="math-log",
@@ -384,6 +393,8 @@ class LokiOperatorCharm(CharmBase):
                 "Loki collects, stores and serves logs, "
                 "alongside optional key-value pairs called labels."
             ),
+            api_docs = "https://grafana.com/docs/loki/latest/reference/loki-http-api/",
+            api_endpoints = {key: f"{self.external_url}{path}" for key, path in api_endpoints.items()}
         )
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -394,7 +394,7 @@ class LokiOperatorCharm(CharmBase):
                 "alongside optional key-value pairs called labels."
             ),
             api_docs = "https://grafana.com/docs/loki/latest/reference/loki-http-api/",
-            api_endpoints = {key: f"{self.external_url}{path}" for key, path in api_endpoints.items()}
+            api_endpoints = {key: f"{self._external_url}{path}" for key, path in api_endpoints.items()}
         )
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -379,8 +379,7 @@ class LokiOperatorCharm(CharmBase):
             "Query range": "/loki/api/v1/query_range",
             "Labels": "/loki/api/v1/labels",
             "Label values": "/loki/api/v1/label/<name>/values",
-            "Prometheus alerts": "/prometheus/api/v1/alerts",
-            "Prometheus rules": "/prometheus/api/v1/alerts",
+            "Alerts": "/prometheus/api/v1/alerts",
             "Format query": "/loki/api/v1/format_query"
         }
         return CatalogueItem(


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
A [recent PR in Catalogue](https://github.com/canonical/catalogue-k8s-operator/pull/184) added functionality to the Catalogue library for Catalogue Items to provide links to their API docs and API endpoints. We need to add these fields when Mimir creates its Catalogue Items.

In tandem with PRs in:
- [Prometheus](https://github.com/canonical/prometheus-k8s-operator/pull/726)
- [Mimir Coordinator](https://github.com/canonical/mimir-coordinator-k8s-operator/pull/177)
- [Loki Coordinator](https://github.com/canonical/loki-coordinator-k8s-operator/pull/88)
- [Grafana](https://github.com/canonical/grafana-k8s-operator/pull/451)

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR links to the upstream [HTTP API docs for Loki](https://grafana.com/docs/loki/latest/reference/loki-http-api/). It also lists some of the more commonly accessed ones to the list of API endpoints. 
The added endpoints are:
```python
api_endpoints = {
            "Instant query": "/loki/api/v1/query",
            "Query range": "/loki/api/v1/query_range",
            "Labels": "/loki/api/v1/labels",
            "Label values": "/loki/api/v1/label/<name>/values",
            "Prometheus alerts": "/prometheus/api/v1/alerts",
            "Prometheus rules": "/prometheus/api/v1/alerts",
            "Format query": "/loki/api/v1/format_query"
        }
```
Note: the PR also performs `charmcraft fetch-lib` to get the latest Catalogue library.
## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
