### PR TITLE
feat!: set a default retention period of 15 days

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -212,15 +212,13 @@ config:
       default: 15
     retention-period:
       description: |
-        Sets a global retention period, in days, for log streams in Loki.
-        The minimum retention period is 1 day, and a value of 0 (default) means "infinity" (disables retention).
-        Loki will not be cleaning up logs if duration is set to 0.
-        This config maps directly to the loki `compactor.retention_enabled` configuration option, which is set to `false` when no retention period is defined.
-        Specifying retention periods for individual streams is not currently supported.
-
-        Ref: https://grafana.com/docs/loki/latest/operations/storage/retention/
+        Sets the global log retention period in Loki (in days).
+        A value of `0` disables deletion, causing logs to be retained indefinitely.
+        The minimum supported non-zero retention period is `1d` (24 hours).
+        Individual/per-stream retention rules are not supported by Loki at this time.
+        For more info, see the Loki docs: https://grafana.com/docs/loki/latest/operations/storage/retention/
       type: int
-      default: 0
+      default: 15
     reporting-enabled:
       description: |
         When disabled, Loki will be configured to not send anonymous usage statistics to stats.grafana.org.

--- a/tests/integration/test_loki_configs.py
+++ b/tests/integration/test_loki_configs.py
@@ -31,12 +31,8 @@ def test_services_running(juju: jubilant.Juju, loki_charm, loki_resources):
 
 def test_retention_configs(juju: jubilant.Juju):
     default_configs = loki_config(juju, app_name)
-    assert all(
-        [
-            default_configs["limits_config"]["retention_period"] == "0s",
-            not default_configs["compactor"]["retention_enabled"],
-        ]
-    )
+    assert default_configs["limits_config"]["retention_period"] == "15d"
+    assert default_configs["compactor"]["retention_enabled"] is True
 
     juju.config(app_name, {"retention-period": "3"})
     juju.wait(


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This charm (and the related Loki HA coordinator charm) currently disabled deletion by default, causing logs to be retained indefinitely by default. This has led to multiple deployments where users have had to patch their PVCs to remediate exhausted disk space.

## Solution
<!-- A summary of the solution addressing the above issue -->
Similar to [Prometheus](https://github.com/canonical/prometheus-k8s-operator/blob/main/charmcraft.yaml#L206-L212), we'll set the default to 15 days.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Previously we had no retention so by default logs would be retained for ever. Since we're changing, I'm marking this as a breaking change.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Pack the charm and deploy. The workload config file should be:
```yaml
...
compactor:
  delete_request_store: filesystem
  retention_enabled: true
  working_directory: /loki/compactor
...
limits_config:
  allow_structured_metadata: true
  ingestion_burst_size_mb: 15.0
  ingestion_rate_mb: 4.0
  per_stream_rate_limit: 4MB
  per_stream_rate_limit_burst: 15MB
  retention_period: 15d
  split_queries_by_interval: '0'
...
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
