### PR TITLE
fix: stop wedging units when the Promtail binary is missing (v1)

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 31
+LIBPATCH = 32
 
 PYDEPS = ["cosl"]
 
@@ -1787,22 +1787,13 @@ class LogProxyConsumer(ConsumerBase):
         self._handle_alert_rules(event.relation)
 
         if self._charm.unit.is_leader():
-            ev = json.loads(event.relation.data[event.app].get("event", "{}"))
-
-            if ev:
-                valid = bool(ev.get("valid", True))
-                errors = ev.get("errors", "")
-
-                if valid and not errors:
-                    self.on.alert_rule_status_changed.emit(valid=valid)
-                else:
-                    self.on.alert_rule_status_changed.emit(valid=valid, errors=errors)
+            self._handle_alert_rule_status_changed(event)
 
         for container in self._containers.values():
             if not container.can_connect():
                 continue
             if self.model.relations[self._relation_name]:
-                if "promtail" not in container.get_plan().services:
+                if not self._is_promtail_set_up(container):
                     self._setup_promtail(container)
                     continue
 
@@ -1815,10 +1806,23 @@ class LogProxyConsumer(ConsumerBase):
                 # Loki may send endpoints late. Don't necessarily start, there may be
                 # no clients
                 if new_config["clients"]:
-                    container.restart(WORKLOAD_SERVICE_NAME)
-                    self.on.log_proxy_endpoint_joined.emit()
+                    if self._restart_promtail(container):
+                        self.on.log_proxy_endpoint_joined.emit()
                 else:
                     self.on.promtail_digest_error.emit("No promtail client endpoints available!")
+
+    def _handle_alert_rule_status_changed(self, event: RelationEvent) -> None:
+        """Relay the alert rule validation status reported by the Loki provider."""
+        ev = json.loads(event.relation.data[event.app].get("event", "{}"))
+
+        if ev:
+            valid = bool(ev.get("valid", True))
+            errors = ev.get("errors", "")
+
+            if valid and not errors:
+                self.on.alert_rule_status_changed.emit(valid=valid)
+            else:
+                self.on.alert_rule_status_changed.emit(valid=valid, errors=errors)
 
     def _on_relation_departed(self, _: RelationEvent) -> None:
         """Event handler for `relation_departed`.
@@ -1838,10 +1842,27 @@ class LogProxyConsumer(ConsumerBase):
                 container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True)
 
             if new_config["clients"]:
-                container.restart(WORKLOAD_SERVICE_NAME)
+                self._restart_promtail(container)
             else:
                 container.stop(WORKLOAD_SERVICE_NAME)
             self.on.log_proxy_endpoint_departed.emit()
+
+    def _restart_promtail(self, container: Container) -> bool:
+        """Restart promtail, surfacing a Pebble failure as a digest error.
+
+        Args:
+            container: the workload container running the promtail service.
+
+        Returns:
+            True on success, False if the restart failed.
+        """
+        try:
+            container.restart(WORKLOAD_SERVICE_NAME)
+        except ChangeError as e:
+            logger.warning("Failed to restart promtail: %s", e)
+            self.on.promtail_digest_error.emit(str(e))
+            return False
+        return True
 
     def _add_pebble_layer(self, workload_binary_path: str, container: Container) -> None:
         """Adds Pebble layer that manages Promtail service in Workload container.
@@ -2202,6 +2223,35 @@ class LogProxyConsumer(ConsumerBase):
 
         return static_configs
 
+    def _promtail_binary_spec(self) -> dict:
+        """The promtail binary metadata advertised on the log-proxy relation."""
+        relations = self._charm.model.relations[self._relation_name]
+        if not relations:
+            return {}
+        relation = relations[0]
+        return json.loads(relation.data[relation.app].get("promtail_binary_zip_url", "{}"))
+
+    def _is_promtail_set_up(self, container: Container) -> bool:
+        """Whether promtail is fully usable in this container.
+
+        Unlike ``_is_promtail_installed`` (binary only), this also requires the
+        pebble service to be registered.
+
+        The pebble plan alone is not proof: if the workload container lost its
+        ephemeral filesystem (e.g. after pod churn) the layer may still be in
+        the plan while the runtime-pushed binary is gone. Trusting the plan and
+        restarting unconditionally wedges the unit
+        (https://github.com/canonical/loki-k8s-operator/issues/659).
+        """
+        if "promtail" not in container.get_plan().services:
+            return False
+        promtail_info = self._promtail_binary_spec().get(self._arch)
+        if not promtail_info:
+            # No promtail binary advertised for this architecture (or nothing
+            # published on the relation yet), so promtail cannot be running here.
+            return False
+        return self._is_promtail_installed(promtail_info, container)
+
     def _setup_promtail(self, container: Container) -> None:
         # Use the first
         relations = self._charm.model.relations[self._relation_name]
@@ -2216,10 +2266,22 @@ class LogProxyConsumer(ConsumerBase):
             relation.data[relation.app].get("promtail_binary_zip_url", "{}")
         )
         if not promtail_binaries:
+            # The Loki charm hasn't published the binary metadata yet; a later
+            # relation-changed will bring us back here.
+            return
+
+        if self._arch not in promtail_binaries:
+            msg = f"No promtail binary available for architecture {self._arch}"
+            logger.warning(msg)
+            self.on.promtail_digest_error.emit(msg)
             return
 
         self._create_directories(container)
-        self._ensure_promtail_binary(promtail_binaries, container)
+        if not self._ensure_promtail_binary(promtail_binaries, container):
+            # Do not add the pebble layer: a service whose command points to a
+            # missing binary would wedge the unit on every restart attempt
+            # (https://github.com/canonical/loki-k8s-operator/issues/659).
+            return
 
         container.push(
             WORKLOAD_CONFIG_PATH,
@@ -2242,9 +2304,18 @@ class LogProxyConsumer(ConsumerBase):
         else:
             self.on.promtail_digest_error.emit("No promtail client endpoints available!")
 
-    def _ensure_promtail_binary(self, promtail_binaries: dict, container: Container):
+    def _ensure_promtail_binary(self, promtail_binaries: dict, container: Container) -> bool:
+        """Ensure the promtail binary is present in the workload container.
+
+        Args:
+            promtail_binaries: dictionary of promtail binaries per architecture.
+            container: container in which promtail must be installed.
+
+        Returns:
+            True if the binary is available, False if it could not be obtained.
+        """
         if self._is_promtail_installed(promtail_binaries[self._arch], container):
-            return
+            return True
 
         try:
             self._obtain_promtail(promtail_binaries[self._arch], container)
@@ -2252,6 +2323,8 @@ class LogProxyConsumer(ConsumerBase):
             msg = f"Promtail binary couldn't be downloaded - {str(e)}"
             logger.warning(msg)
             self.on.promtail_digest_error.emit(msg)
+            return False
+        return True
 
     def _is_promtail_installed(self, promtail_info: dict, container: Container) -> bool:
         """Determine if promtail has already been installed to the container.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,12 @@
 import logging
+import shlex
 from unittest.mock import PropertyMock, patch
 
 import ops
 import pytest
 from cosl.loki_logger import LokiHandler
+from helpers import pebble_change_error
+from ops.model import Container as OpsContainer
 from ops.testing import Context
 from scenario import Container, Exec
 
@@ -56,3 +59,35 @@ def loki_container():
         layers={"loki": ops.pebble.Layer({"services": {"loki": {}}})},
         service_statuses={"loki": ops.pebble.ServiceStatus.INACTIVE},
     )
+
+
+@pytest.fixture
+def pebble_restart_checks_binary():
+    """Make the simulated Pebble reject service starts whose executable is absent.
+
+    The stock ops.testing Pebble mock only checks that the service exists in the
+    plan; real Pebble fails the start with ``fork/exec ...: no such file or
+    directory``. Use this fixture whenever a test needs that fidelity (e.g.
+    regression tests for https://github.com/canonical/loki-k8s-operator/issues/659).
+    """
+    original_restart = OpsContainer.restart
+
+    def restart(self, *service_names):
+        plan = self.get_plan()
+        for name in service_names:
+            binary = shlex.split(plan.services[name].command)[0]
+            try:
+                self.list_files(binary)
+                missing = False
+            except Exception:
+                missing = True
+            if missing:
+                raise pebble_change_error(
+                    "cannot perform the following tasks:\n"
+                    f'- Start service "{name}" (cannot start service: fork/exec '
+                    f"{binary}: no such file or directory)"
+                )
+        return original_restart(self, *service_names)
+
+    with patch.object(OpsContainer, "restart", restart):
+        yield

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -2,13 +2,32 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import yaml
+from ops.pebble import Change, ChangeError, ChangeID
 
 
 def tautology(*_, **__) -> bool:
     return True
+
+
+def pebble_change_error(message: str) -> ChangeError:
+    """Build a ChangeError like the one real Pebble raises for a failed service start."""
+    now = datetime.now(timezone.utc)
+    change = Change(
+        id=ChangeID("1"),
+        kind="start",
+        summary="Start service",
+        status="Error",
+        tasks=[],
+        ready=True,
+        err=message,
+        spawn_time=now,
+        ready_time=now,
+    )
+    return ChangeError(message, change)
 
 
 k8s_resource_multipatch = patch.multiple(

--- a/tests/unit/test_log_proxy_consumer_v1.py
+++ b/tests/unit/test_log_proxy_consumer_v1.py
@@ -1,0 +1,335 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Expected behaviour tests for https://github.com/canonical/loki-k8s-operator/issues/659.
+
+After workload container churn, LogProxyConsumer can be left in a state where the
+pebble plan references /opt/promtail/promtail-static-amd64 but the binary is gone
+(it lives on ephemeral storage and is pushed at runtime by the charm).
+
+These tests encode the desired post-fix behaviour:
+
+1. ``_setup_promtail`` must be atomic: if obtaining the promtail binary fails,
+   the pebble layer must not reference a service whose executable is absent.
+2. ``_on_relation_changed`` must not trust the pebble plan alone: when the plan
+   references promtail but the binary is missing, it must fall back to
+   re-provisioning instead of calling ``container.restart()`` unconditionally
+   (real Pebble fails that start with ``fork/exec ... no such file or
+   directory``, wedging the unit in hook error forever).
+3. After a successful provisioning, subsequent relation-changed events must
+   never wedge the unit, even when the workload container lost its ephemeral
+   filesystem in between (pod/container churn).
+
+The ``pebble_restart_checks_binary`` fixture (defined in
+``tests/unit/conftest.py``) teaches the simulated Pebble what real Pebble does:
+reject service starts whose executable is absent.
+"""
+
+import json
+import platform
+from hashlib import sha256
+from unittest.mock import patch
+from urllib.error import URLError
+
+import pytest
+from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
+from helpers import pebble_change_error
+from ops.charm import CharmBase
+from ops.framework import StoredState
+from ops.model import Container as OpsContainer
+from ops.pebble import Layer, ServiceStatus
+from ops.testing import Context
+from scenario import Container, Model, Relation, State
+
+WORKLOAD_BINARY_PATH = "/opt/promtail/promtail-static-amd64"
+FAKE_BINARY_CONTENT = b"#!fake-promtail-binary"
+
+META = {
+    "name": "consumer-k8s",
+    "requires": {"log-proxy": {"interface": "loki_push_api", "optional": True}},
+    "containers": {"app": {"resource": "app-image"}},
+}
+
+
+class LogProxyConsumerCharm(CharmBase):
+    _stored = StoredState()
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._stored.set_default(promtail_digest_errors=0, endpoint_joined_events=0)
+        self.log_proxy = LogProxyConsumer(
+            charm=self,
+            logs_scheme={"app": {"log-files": ["/var/log/app/*.log"]}},
+        )
+        self.framework.observe(
+            self.log_proxy.on.promtail_digest_error, self._register_digest_error
+        )
+        self.framework.observe(
+            self.log_proxy.on.log_proxy_endpoint_joined, self._register_endpoint_joined
+        )
+
+    def _register_digest_error(self, _):
+        self._stored.promtail_digest_errors += 1
+
+    def _register_endpoint_joined(self, _):
+        self._stored.endpoint_joined_events += 1
+
+
+@pytest.fixture
+def app_container():
+    return Container("app", can_connect=True)
+
+
+@pytest.fixture
+def consumer_context():
+    return Context(LogProxyConsumerCharm, meta=META)
+
+
+@pytest.fixture
+def log_proxy_relation():
+    """A log-proxy relation as the Loki provider side would have populated it."""
+    digest = sha256(FAKE_BINARY_CONTENT).hexdigest()
+    arch = "amd64" if platform.machine() == "x86_64" else platform.machine()
+    return Relation(
+        endpoint="log-proxy",
+        remote_app_name="loki",
+        remote_app_data={
+            "promtail_binary_zip_url": json.dumps(
+                {
+                    arch: {
+                        "filename": "promtail-static-amd64",
+                        "zipsha": digest,
+                        "binsha": digest,
+                        "url": "http://promtail.invalid/promtail.zip",
+                    }
+                }
+            )
+        },
+        remote_units_data={
+            0: {"endpoint": json.dumps({"url": "http://loki:3100/loki/api/v1/push"})}
+        },
+    )
+
+
+def _base_state(container: Container, relation: Relation) -> State:
+    return State(
+        leader=True,
+        containers=[container],
+        relations=[relation],
+        model=Model(name="MODEL", uuid="20ce8299-3634-4bef-8bd8-5ace6c8816b4"),
+    )
+
+
+
+def _plan_service_names(container_state: Container) -> set:
+    services = {}
+    for layer in container_state.layers.values():
+        services.update(layer.services)
+    return set(services)
+
+
+def _wedged_container() -> Container:
+    """Container in the inconsistent state from the issue: layer added, binary gone."""
+    return Container(
+        "app",
+        can_connect=True,
+        layers={
+            "app": Layer(
+                {
+                    "summary": "promtail layer",
+                    "services": {
+                        "promtail": {
+                            "override": "replace",
+                            "summary": "promtail",
+                            "command": (
+                                f"{WORKLOAD_BINARY_PATH} "
+                                "-config.file=/etc/promtail/promtail_config.yaml"
+                            ),
+                            "startup": "disabled",
+                        }
+                    },
+                }
+            )
+        },
+    )
+
+
+def test_binary_not_advertised_for_this_architecture_does_not_crash_hook(
+    consumer_context,
+    app_container,
+    pebble_restart_checks_binary,
+):
+    """A spec without our architecture must be reported, not raise KeyError."""
+    # GIVEN Loki advertises a promtail binary only for an architecture we are not running on
+    foreign_arch_relation = Relation(
+        endpoint="log-proxy",
+        remote_app_name="loki",
+        remote_app_data={
+            "promtail_binary_zip_url": json.dumps(
+                {"s390x": {"filename": "promtail-static-s390x", "zipsha": "x", "binsha": "y"}}
+            )
+        },
+        remote_units_data={
+            0: {"endpoint": json.dumps({"url": "http://loki:3100/loki/api/v1/push"})}
+        },
+    )
+    state = _base_state(app_container, foreign_arch_relation)
+
+    # WHEN the log-proxy relation changes
+    state_out = consumer_context.run(
+        consumer_context.on.relation_changed(foreign_arch_relation, remote_unit=0), state
+    )
+
+    # THEN the hook survives, no promtail service is registered, and the operator is told why
+    assert "promtail" not in _plan_service_names(state_out.get_container("app"))
+    with consumer_context(consumer_context.on.update_status(), state_out) as mgr:
+        assert mgr.charm._stored.promtail_digest_errors == 1
+
+
+def test_failed_binary_download_does_not_add_pebble_layer(
+    consumer_context,
+    app_container,
+    log_proxy_relation,
+    pebble_restart_checks_binary,
+    tmp_path,
+):
+    """Provisioning must be atomic: no layer referencing a binary that isn't there."""
+    # GIVEN no promtail binary is cached in the charm container
+    state = _base_state(app_container, log_proxy_relation)
+    with (
+        patch("charms.loki_k8s.v1.loki_push_api.BINARY_DIR", str(tmp_path)),
+        patch(
+            "charms.loki_k8s.v1.loki_push_api.LogProxyConsumer."
+            "_download_and_push_promtail_to_workload"
+        ) as mock_download,
+    ):
+        # AND downloading it fails (e.g. no juju proxy configured)
+        mock_download.side_effect = URLError(reason="[Errno 110] Connection timed out")
+
+        # WHEN the log-proxy relation changes and provisioning is attempted
+        state_out = consumer_context.run(
+            consumer_context.on.relation_changed(log_proxy_relation, remote_unit=0), state
+        )
+
+    # THEN no promtail service is left pointing at the missing binary
+    assert "promtail" not in _plan_service_names(state_out.get_container("app"))
+    # AND the failure is surfaced once, without erroring the hook
+    with consumer_context(consumer_context.on.update_status(), state_out) as mgr:
+        assert mgr.charm._stored.promtail_digest_errors == 1
+
+
+def test_relation_changed_heals_wedged_container_by_reprovisioning(
+    consumer_context,
+    log_proxy_relation,
+    pebble_restart_checks_binary,
+    tmp_path,
+):
+    """A wedged unit must recover on relation-changed instead of erroring forever."""
+    # GIVEN a container wedged as in the issue: promtail is in the pebble plan
+    # but its binary is gone from the ephemeral filesystem
+    state = _base_state(_wedged_container(), log_proxy_relation)
+    # AND the promtail binary is available again (e.g. the network recovered)
+    (tmp_path / "promtail-static-amd64").write_bytes(FAKE_BINARY_CONTENT)
+
+    with patch("charms.loki_k8s.v1.loki_push_api.BINARY_DIR", str(tmp_path)):
+        # WHEN the log-proxy relation changes
+        state_out = consumer_context.run(
+            consumer_context.on.relation_changed(log_proxy_relation, remote_unit=0), state
+        )
+
+    # THEN promtail is re-provisioned and running, with nothing reported as broken
+    container_out = state_out.get_container("app")
+    assert container_out.service_statuses["promtail"] == ServiceStatus.ACTIVE
+    with consumer_context(consumer_context.on.update_status(), state_out) as mgr:
+        assert mgr.charm._stored.promtail_digest_errors == 0
+
+
+def test_second_relation_changed_after_churn_does_not_wedge_unit(
+    consumer_context,
+    app_container,
+    log_proxy_relation,
+    pebble_restart_checks_binary,
+    tmp_path,
+):
+    """Later relation-changed events must never wedge the unit, even after churn."""
+    # GIVEN the promtail binary is cached in the charm container
+    (tmp_path / "promtail-static-amd64").write_bytes(FAKE_BINARY_CONTENT)
+    state = _base_state(app_container, log_proxy_relation)
+
+    with patch("charms.loki_k8s.v1.loki_push_api.BINARY_DIR", str(tmp_path)):
+        # AND a first relation-changed provisioned and started promtail
+        state_out = consumer_context.run(
+            consumer_context.on.relation_changed(log_proxy_relation, remote_unit=0), state
+        )
+        assert state_out.get_container("app").service_statuses["promtail"] == (
+            ServiceStatus.ACTIVE
+        )
+
+        # WHEN a second relation-changed arrives after the workload container lost its
+        # ephemeral filesystem (scenario does not carry files pushed in a previous run,
+        # which mirrors exactly what Kubernetes does on pod/container churn)
+        healthy_relation = state_out.get_relations("log-proxy")[0]
+        state_out2 = consumer_context.run(
+            consumer_context.on.relation_changed(healthy_relation, remote_unit=0),
+            state_out,
+        )
+
+    # THEN the unit does not wedge: promtail is set up again and keeps running
+    assert (
+        state_out2.get_container("app").service_statuses["promtail"] == ServiceStatus.ACTIVE
+    )
+
+
+def test_already_set_up_container_restarts_promtail_and_reports_endpoint_joined(
+    consumer_context,
+    log_proxy_relation,
+):
+    """Fast path: promtail already set up, so relation-changed only restarts it."""
+    # GIVEN promtail is already set up: the service is in the plan and the binary is installed
+    state = _base_state(_wedged_container(), log_proxy_relation)
+
+    with patch(
+        "charms.loki_k8s.v1.loki_push_api.LogProxyConsumer._is_promtail_installed",
+        return_value=True,
+    ):
+        # WHEN the log-proxy relation changes
+        state_out = consumer_context.run(
+            consumer_context.on.relation_changed(log_proxy_relation, remote_unit=0), state
+        )
+
+    # THEN promtail is restarted and the endpoint is reported as joined, with no errors
+    assert state_out.get_container("app").service_statuses["promtail"] == ServiceStatus.ACTIVE
+    with consumer_context(consumer_context.on.update_status(), state_out) as mgr:
+        assert mgr.charm._stored.endpoint_joined_events == 1
+        assert mgr.charm._stored.promtail_digest_errors == 0
+
+
+def test_restart_failure_on_set_up_container_does_not_error_the_unit(
+    consumer_context,
+    log_proxy_relation,
+):
+    """A Pebble failure while restarting promtail must be reported, not crash the hook."""
+    # GIVEN promtail is already set up in the container
+    state = _base_state(_wedged_container(), log_proxy_relation)
+    # AND Pebble refuses to restart it, as it does while a container is terminating
+    restart_error = pebble_change_error(
+        'cannot perform the following tasks:\n- Start service "promtail" '
+        "(cannot start service while terminating)"
+    )
+
+    with (
+        patch(
+            "charms.loki_k8s.v1.loki_push_api.LogProxyConsumer._is_promtail_installed",
+            return_value=True,
+        ),
+        patch.object(OpsContainer, "restart", side_effect=restart_error),
+    ):
+        # WHEN the log-proxy relation changes
+        state_out = consumer_context.run(
+            consumer_context.on.relation_changed(log_proxy_relation, remote_unit=0), state
+        )
+
+    # THEN the failure is surfaced as a digest error instead of erroring the hook
+    with consumer_context(consumer_context.on.update_status(), state_out) as mgr:
+        assert mgr.charm._stored.promtail_digest_errors == 1
+        assert mgr.charm._stored.endpoint_joined_events == 0


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes [#659](https://github.com/canonical/loki-k8s-operator/issues/659).

In `loki_push_api` v1, `LogProxyConsumer._on_relation_changed` decided whether Promtail was provisioned by looking **only** at the Pebble plan. After the workload container loses its ephemeral filesystem (pod/container churn), the plan still lists the `promtail` service while the runtime-pushed binary at `/opt/promtail/promtail-static-amd64` is gone. The handler then called `container.restart("promtail")` unconditionally, Pebble failed with `fork/exec ...: no such file or directory`, and the hook errored out. `juju resolved` re-ran the same hook and failed identically, only deleting the pod recovered the unit.


## Solution
<!-- A summary of the solution addressing the above issue -->

Four changes in the v1 library (`LIBPATCH` 31 → 32):

1. **`_is_promtail_set_up()`**: `relation-changed` now requires *both* the service in the plan **and** the binary in the container. Otherwise it re-provisions instead of restarting blindly, so a wedged unit heals itself.
2. **Atomic provisioning**: `_setup_promtail()` no longer adds the Pebble layer when the binary could not be obtained (`_ensure_promtail_binary()` now returns a bool), so the inconsistent "service registered, binary absent" state is never created in the first place.
3. **`_restart_promtail()`**: the restarts in `relation-changed` / `relation-departed` are wrapped: a `ChangeError` is surfaced as `promtail_digest_error` instead of erroring the hook.
4. **Architecture guard**: `_setup_promtail()` used to raise an uncaught `KeyError` when the relation spec had no entry for the unit's architecture; it now reports it as a digest error.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

- The Promtail binary is not part of the workload image: the charm pushes it at runtime into `/opt/promtail` in the workload container, which is **ephemeral**. Kubernetes discards it on every container recreation, while Juju relation data and the Pebble plan can still make the charm believe Promtail is provisioned.
- `*-pebble-ready` is not a sufficient safety net: provisioning can fail halfway (e.g. a failed download behind a proxy) and, as in this issue, it is the *later* `relation-changed` events that wedge the unit.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

- `tox -e unit`: 6 new tests in `tests/unit/test_log_proxy_consumer_v1.py`


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

- Library-only change: no charm config, relation or workload interface changes. Consumers must `charmcraft fetch-lib charms.loki_k8s.v1.loki_push_api` (LIBPATCH 32) and rebuild to get the fix.
- Behaviour change for consumers: a failed Promtail restart, or a missing binary for the unit's architecture, is now emitted as `promtail_digest_error` instead of raising from the hook charms that relied on hook errors to notice these will now see them in status/logs instead.
- While the binary cannot be downloaded, `promtail` is no longer registered in the Pebble plan; it is added as soon as the download succeeds.